### PR TITLE
Small improvements to pom.xml

### DIFF
--- a/Code/pom.xml
+++ b/Code/pom.xml
@@ -33,16 +33,27 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.5.3</version>
         <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
           <archive>
             <manifest>
-              <addClasspath>true</addClasspath>
               <mainClass>nl.utwente.group10.App</mainClass>
             </manifest>
           </archive>
         </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/Code/pom.xml
+++ b/Code/pom.xml
@@ -33,7 +33,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.5</version>
         <configuration>
@@ -46,7 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.14</version>
         <executions>

--- a/Code/pom.xml
+++ b/Code/pom.xml
@@ -84,47 +84,8 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <instrumentation>
-            <ignores>
-            </ignores>
-            <excludes>
-              <exclude>nl/utwente/group10/haskell/typeparser/*.class</exclude>
-              <exclude>nl/utwente/**/*Test.class</exclude>
-            </excludes>
-          </instrumentation>
-          <check>
-          </check>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/Code/src/main/java/nl/utwente/group10/App.java
+++ b/Code/src/main/java/nl/utwente/group10/App.java
@@ -1,10 +1,7 @@
 package nl.utwente.group10;
 
-import nl.utwente.group10.ghcj.GhciSession;
-
 public class App {
     public static void main(String[] args) throws Exception {
-        GhciSession session = new GhciSession();
-        session.close();
+		System.out.println("Hello, world!");
     }
 }


### PR DESCRIPTION
This PR cleans up some unneeded stuff (and Cobertura) from the pom.xml file to
make it a bit easier to read. It also replaces the jar generation plugin with
one that bundles dependencies, which makes it easier to distribute the end
result.