### PR TITLE
Add xvfb virtual framebuffer to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: java
 jdk:
  - oraclejdk8
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -y ghc
+ - "export DISPLAY=:99.0"
+ - "sh -e /etc/init.d/xvfb start"
+ - "sudo apt-get update -qq"
+ - "sudo apt-get install -y ghc"
 script: 
  - cd Code && mvn test
 cache:


### PR DESCRIPTION
This adds a virtual framebuffer to Travis, which means that tests that
use JavaFX should no longer complain about not being to open a display.