### PR TITLE
Check XML files during maven build

### DIFF
--- a/Code/pom.xml
+++ b/Code/pom.xml
@@ -93,6 +93,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <validationSets>
+            <validationSet>
+              <dir>src/main/resources/catalog/</dir>
+            </validationSet>
+            <validationSet>
+              <dir>src/main/resources/catalog/</dir>
+              <includes><include>functions.xml</include></includes>
+              <systemId>src/main/resources/catalog/functions.xsd</systemId>
+            </validationSet>
+          </validationSets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <properties>


### PR DESCRIPTION
Maven builds will now fail when the catalog XML file is invalid.