### PR TITLE
Refactoring of FunctionBlock

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -15,8 +15,8 @@ public class Block extends StackPane {
 	 * Set the selected boolean state of this Block
 	 * @param selectedState
 	 */
-		public void setSelected(boolean selectedState){
-			//TODO If another object is selected then deselect it first!!
-			isSelected = selectedState;
-		}
+	public void setSelected(boolean selectedState) {
+		//TODO If another object is selected then deselect it first!!
+		isSelected = selectedState;
+	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -12,11 +12,11 @@ public class Block extends StackPane {
 	private boolean isSelected = false;
 	
 	/**
-	 * Set the selected state of this Block
-	 * @param Selected False/True
+	 * Set the selected boolean state of this Block
+	 * @param selectedState
 	 */
-		public void setSelected(boolean bool){
+		public void setSelected(boolean selectedState){
 			//TODO If another object is selected then deselect it first!!
-			isSelected = bool;
+			isSelected = selectedState;
 		}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -1,0 +1,22 @@
+package nl.utwente.group10.ui.components;
+
+import javafx.scene.layout.StackPane;
+
+/**
+ * Base UI Component that other visual elements will extend from.
+ * If common functionality is found it should be refactored to here.
+ */
+public class Block extends StackPane {
+
+	/** Selected state of this Block*/
+	private boolean isSelected = false;
+	
+	/**
+	 * Set the selected state of this Block
+	 * @param Selected False/True
+	 */
+		public void setSelected(boolean bool){
+			//TODO If another object is selected then deselect it first!!
+			isSelected = bool;
+		}
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -43,6 +43,20 @@ public class FunctionBlock extends Block{
 	}
 	
 	/**
+	 * Method that creates a newInstance of this class along with it's visual representation
+	 * @param the number of arguments this FunctionBlock can hold
+	 * @param the name of this FunctionBlock
+	 * @return a new instance of this class
+	 * @throws IOException
+	 */
+	public static FunctionBlock newInstance(int numberOfArguments, String name) throws IOException{
+		FunctionBlock functionBlock = newInstance(numberOfArguments);
+		functionBlock.setName(name);
+		
+		return functionBlock;
+	}
+	
+	/**
 	 * Executes this FunctionBlock and returns the output as a String
 	 * @return Output of the Function
 	 */

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -18,11 +18,11 @@ import javafx.scene.shape.Rectangle;
  * represents a Haskell function together with it's arguments and
  * visual representation.
  */
-public class FunctionBlock extends StackPane{
-	//The arguments this FunctionBlock holds
+public class FunctionBlock extends Block{
+	/**The arguments this FunctionBlock holds.**/
 	private String[] arguments;
+	/** The name of this Function.**/
 	private String functionName;
-	private boolean isSelected = false;
 	
 	/**
 	 * Method that creates a newInstance of this class along with it's visual representation
@@ -31,32 +31,40 @@ public class FunctionBlock extends StackPane{
 	 * @throws IOException
 	 */
 	public static FunctionBlock newInstance(int numberOfArguments){
-		//TODO Prettier resource loading
-		//TODO better factory
-		FunctionBlock functionBlock = null;
+		FunctionBlock functionBlock;
 		try{
 			functionBlock = (FunctionBlock) FXMLLoader.load(Main.class.getResource("/ui/FunctionBlock.fxml"), null, new TactileBuilderFactory());
 			functionBlock.initializeArguments(numberOfArguments);
 		}catch(IOException e){
 			e.printStackTrace();
+			functionBlock = null;
 		}
 		return functionBlock;
 	}
 	
-	//TODO To be implemented method that will parse code into Haskell interface
-	// and returns the result
+	/**
+	 * Executes this FunctionBlock and returns the output as a String
+	 * @return Output of the Function
+	 */
 	public String executeMethod(){		
 		return new String("DEBUG-OUTPUT");
 	}
 	
+	/**
+	 * Nest another Node object within this FunctionBlock
+	 * @param node to nest
+	 */
 	public void nest(Node node){
 		Pane nestSPace = (Pane) this.lookup("#nest_space");
 		((Label) this.lookup("#label_function_name")).setText("Higher order function");
 		nestSPace.getChildren().add(node);
 	}
 	
-	//Private method to initialize the argument fields for this function block.
-	//All arguments will be stored as Strings.
+	/**
+	 * Private method to initialize the argument fields for this function block.
+	 * All arguments will be stored as Strings.
+	 * @param numberOfArguments
+	 */
 	private void initializeArguments(int numberOfArguments){
 		arguments = new String[numberOfArguments];
 	}
@@ -68,12 +76,6 @@ public class FunctionBlock extends StackPane{
 	 */
 	public void setArgument(int i,String arg){
 		arguments[i] = arg;
-	}
-	
-	//Selects or deselects this FunctionBlock
-	public void setSelected(boolean bool){
-		//If another object is selected then deselect it first!!
-		isSelected = bool;
 	}
 	
 	/**

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -18,8 +18,8 @@ import javafx.scene.shape.Rectangle;
  * represents a Haskell function together with it's arguments and
  * visual representation.
  */
-public class FunctionBlock extends Block{
-	/**The arguments this FunctionBlock holds.**/
+public class FunctionBlock extends Block {
+	/** The arguments this FunctionBlock holds.**/
 	private String[] arguments;
 	/** The name of this Function.**/
 	private String functionName;
@@ -30,7 +30,7 @@ public class FunctionBlock extends Block{
 	 * @return a new instance of this class
 	 * @throws IOException
 	 */
-	public static FunctionBlock newInstance(int numberOfArguments){
+	public static FunctionBlock newInstance(int numberOfArguments) {
 		FunctionBlock functionBlock;
 		try{
 			functionBlock = (FunctionBlock) FXMLLoader.load(Main.class.getResource("/ui/FunctionBlock.fxml"), null, new TactileBuilderFactory());
@@ -49,7 +49,7 @@ public class FunctionBlock extends Block{
 	 * @return a new instance of this class
 	 * @throws IOException
 	 */
-	public static FunctionBlock newInstance(int numberOfArguments, String name) throws IOException{
+	public static FunctionBlock newInstance(int numberOfArguments, String name) throws IOException {
 		FunctionBlock functionBlock = newInstance(numberOfArguments);
 		functionBlock.setName(name);
 		
@@ -60,7 +60,7 @@ public class FunctionBlock extends Block{
 	 * Executes this FunctionBlock and returns the output as a String
 	 * @return Output of the Function
 	 */
-	public String executeMethod(){		
+	public String executeMethod() {		
 		return new String("DEBUG-OUTPUT");
 	}
 	
@@ -68,7 +68,7 @@ public class FunctionBlock extends Block{
 	 * Nest another Node object within this FunctionBlock
 	 * @param node to nest
 	 */
-	public void nest(Node node){
+	public void nest(Node node) {
 		Pane nestSPace = (Pane) this.lookup("#nest_space");
 		((Label) this.lookup("#label_function_name")).setText("Higher order function");
 		nestSPace.getChildren().add(node);
@@ -79,7 +79,7 @@ public class FunctionBlock extends Block{
 	 * All arguments will be stored as Strings.
 	 * @param numberOfArguments
 	 */
-	private void initializeArguments(int numberOfArguments){
+	private void initializeArguments(int numberOfArguments) {
 		arguments = new String[numberOfArguments];
 	}
 	
@@ -88,7 +88,7 @@ public class FunctionBlock extends Block{
 	 * @param the index of the argument field
 	 * @param the value that the argument should be changed to
 	 */
-	public void setArgument(int i,String arg){
+	public void setArgument(int i,String arg) {
 		arguments[i] = arg;
 	}
 	
@@ -96,7 +96,7 @@ public class FunctionBlock extends Block{
 	 * Method to set the name of this FunctionBlock
 	 * @param name
 	 */
-	public void setName(String name){
+	public void setName(String name) {
 		functionName = name;
 		Label label = ((Label)this.lookup("#label_function_name"));
 		label.setText(functionName);

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -30,15 +30,10 @@ public class FunctionBlock extends Block {
 	 * @return a new instance of this class
 	 * @throws IOException
 	 */
-	public static FunctionBlock newInstance(int numberOfArguments) {
-		FunctionBlock functionBlock;
-		try{
-			functionBlock = (FunctionBlock) FXMLLoader.load(Main.class.getResource("/ui/FunctionBlock.fxml"), null, new TactileBuilderFactory());
-			functionBlock.initializeArguments(numberOfArguments);
-		}catch(IOException e){
-			e.printStackTrace();
-			functionBlock = null;
-		}
+	public static FunctionBlock newInstance(int numberOfArguments) throws IOException {
+		FunctionBlock functionBlock = (FunctionBlock) FXMLLoader.load(Main.class.getResource("/ui/FunctionBlock.fxml"), null, new TactileBuilderFactory());
+		functionBlock.initializeArguments(numberOfArguments);
+
 		return functionBlock;
 	}
 	
@@ -69,14 +64,15 @@ public class FunctionBlock extends Block {
 	 * @param node to nest
 	 */
 	public void nest(Node node) {
-		Pane nestSPace = (Pane) this.lookup("#nest_space");
+		Pane nestSpace = (Pane) this.lookup("#nest_space");
 		((Label) this.lookup("#label_function_name")).setText("Higher order function");
-		nestSPace.getChildren().add(node);
+		nestSpace.getChildren().add(node);
 	}
 	
 	/**
 	 * Private method to initialize the argument fields for this function block.
-	 * All arguments will be stored as Strings.
+	 * All arguments will are defined as Strings and will be stored as such.
+	 * An Integer value of 6 will also be stored as a String "6"
 	 * @param numberOfArguments
 	 */
 	private void initializeArguments(int numberOfArguments) {


### PR DESCRIPTION
Refactored FunctionBlock in order to make feature expansion easier.
FunctionBlock now extends Block and certain methods have subsequently been moved from FunctionBlock to Block.

newInstance of FunctionBlock has been slightly rewritten and a second version of newInstance has been introduced to enable the instantiation of FunctionBlocks with initialised names.