### PR TITLE
function block select & drag gesture

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -9,13 +9,9 @@ import nl.utwente.group10.ui.gestures.GestureCallBack;
 public class CustomUIPane extends TactilePane implements GestureCallBack {
 
 	public CustomUIPane() {
-		CustomGesture cg = new CustomGesture(this, this);
 	}
 
 	@Override
 	public void handleCustomEvent(UIEvent event) {
-		EventType<UIEvent> eventType = (EventType<UIEvent>) event
-				.getEventType();
-	
 	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -3,7 +3,7 @@ package nl.utwente.group10.ui;
 import javafx.event.EventType;
 import nl.utwente.ewi.caes.tactilefx.control.TactilePane;
 import nl.utwente.group10.ui.gestures.CustomGesture;
-import nl.utwente.group10.ui.gestures.CustomGestureEvent;
+import nl.utwente.group10.ui.gestures.UIEvent;
 import nl.utwente.group10.ui.gestures.GestureCallBack;
 
 public class CustomUIPane extends TactilePane implements GestureCallBack {
@@ -13,18 +13,9 @@ public class CustomUIPane extends TactilePane implements GestureCallBack {
 	}
 
 	@Override
-	public void handleCustomEvent(CustomGestureEvent event) {
-		EventType<CustomGestureEvent> eventType = (EventType<CustomGestureEvent>) event
+	public void handleCustomEvent(UIEvent event) {
+		EventType<UIEvent> eventType = (EventType<UIEvent>) event
 				.getEventType();
-		if (eventType.equals(CustomGestureEvent.TAP)) {
-			System.out.println("CustomUIPane -> CustomGestureEvent.TAP");
-			// TODO:select element if this element has the property to be
-			// selected
-		} else if (eventType.equals(CustomGestureEvent.TAP_HOLD)) {
-			System.out.println("CustomUIPane -> CustomGestureEvent.TAP_HOLD");
-			// TODO: open the quick-menu of an element if this is possible
-		} else if (eventType.equals(CustomGestureEvent.ANY)) {
-			System.out.println("CustomUIPane -> CustomGestureEvent.ANY");
-		}
+	
 	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -21,24 +21,24 @@ public class Main extends Application {
 
 		CustomUIPane tactilePane = FXMLLoader.load(this.getClass().getResource("/ui/Main.fxml"), null, new TactileBuilderFactory());
 
-		FunctionBlock functionBlock = FunctionBlock.newInstance(2);
+		FunctionBlock functionBlock = FunctionBlock.newInstance(2, tactilePane);
 		functionBlock.setName("TestTest");
-		FunctionBlock functionBlock2 = FunctionBlock.newInstance(0);
-		FunctionBlock functionBlock3 = FunctionBlock.newInstance(0);
-		FunctionBlock functionBlock4 = FunctionBlock.newInstance(0);
+		FunctionBlock functionBlock2 = FunctionBlock.newInstance(0, tactilePane);
+		FunctionBlock functionBlock3 = FunctionBlock.newInstance(0, tactilePane);
+		FunctionBlock functionBlock4 = FunctionBlock.newInstance(0, tactilePane);
 
-		functionBlock4.nest(FunctionBlock.newInstance(0));
-		functionBlock3.nest(FunctionBlock.newInstance(0));
-		functionBlock3.nest(FunctionBlock.newInstance(0));
+		functionBlock4.nest(FunctionBlock.newInstance(0, tactilePane));
+		functionBlock3.nest(FunctionBlock.newInstance(0, tactilePane));
+		functionBlock3.nest(FunctionBlock.newInstance(0, tactilePane));
 		functionBlock2.nest(functionBlock4);
 		functionBlock2.nest(functionBlock3);
 
-		functionBlock.nest(FunctionBlock.newInstance(0));
-		functionBlock.nest(FunctionBlock.newInstance(0));
-		functionBlock.nest(FunctionBlock.newInstance(0));
+		functionBlock.nest(FunctionBlock.newInstance(0, tactilePane));
+		functionBlock.nest(FunctionBlock.newInstance(0, tactilePane));
+		functionBlock.nest(FunctionBlock.newInstance(0, tactilePane));
 		tactilePane.getChildren().add(functionBlock);
 		tactilePane.getChildren().add(functionBlock2);
-		tactilePane.getChildren().add(FunctionBlock.newInstance(0));
+		tactilePane.getChildren().add(FunctionBlock.newInstance(0, tactilePane));
 
 		// Init Control Pane
 		FlowPane controlLayout = new FlowPane();

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -29,7 +29,7 @@ public class Block extends StackPane implements GestureCallBack {
 	
 	@Override
 	public void handleCustomEvent(UIEvent event) {
-		EventType<UIEvent> eventType = (EventType<UIEvent>) event
+		EventType eventType = event
 				.getEventType();
 		if (eventType.equals(UIEvent.TAP)) {
 			for(Node n : cup.getChildren()){

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -1,15 +1,22 @@
 package nl.utwente.group10.ui.components;
 
+import nl.utwente.group10.ui.CustomUIPane;
+import nl.utwente.group10.ui.gestures.GestureCallBack;
+import nl.utwente.group10.ui.gestures.UIEvent;
+import javafx.event.EventType;
+import javafx.scene.Node;
 import javafx.scene.layout.StackPane;
 
 /**
  * Base UI Component that other visual elements will extend from.
  * If common functionality is found it should be refactored to here.
  */
-public class Block extends StackPane {
+public class Block extends StackPane implements GestureCallBack {
 
 	/** Selected state of this Block*/
 	private boolean isSelected = false;
+	
+	protected static CustomUIPane cup;
 	
 	/**
 	 * Set the selected boolean state of this Block
@@ -18,5 +25,24 @@ public class Block extends StackPane {
 	public void setSelected(boolean selectedState) {
 		//TODO If another object is selected then deselect it first!!
 		isSelected = selectedState;
+	}
+	
+	@Override
+	public void handleCustomEvent(UIEvent event) {
+		EventType<UIEvent> eventType = (EventType<UIEvent>) event
+				.getEventType();
+		if (eventType.equals(UIEvent.TAP)) {
+			for(Node n : cup.getChildren()){
+				if(n instanceof Block){
+					if(((Block) n).isSelected){
+						((Block) n).setSelected(false);
+					}
+				}
+			}
+			this.setSelected(true);
+			System.out.println("Block is selected");
+		} else if (eventType.equals(UIEvent.TAP_HOLD)) {
+			//TODO: open the quick-menu
+		}
 	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -34,6 +34,7 @@ public class FunctionBlock extends Block {
 	/**
 	 * Method that creates a newInstance of this class along with it's visual representation
 	 * @param the number of arguments this FunctionBlock can hold
+	 * @param pane: The CustomUIPane in which this FunctionBlock exists. Via this this FunctionBlock knows which other FunctionBlocks exist.
 	 * @return a new instance of this class
 	 * @throws IOException
 	 */

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -3,7 +3,12 @@ package nl.utwente.group10.ui.components;
 import java.io.IOException;
 
 import nl.utwente.ewi.caes.tactilefx.fxml.TactileBuilderFactory;
+import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.Main;
+import nl.utwente.group10.ui.gestures.CustomGesture;
+import nl.utwente.group10.ui.gestures.UIEvent;
+import nl.utwente.group10.ui.gestures.GestureCallBack;
+import javafx.event.EventType;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
@@ -23,17 +28,20 @@ public class FunctionBlock extends Block {
 	private String[] arguments;
 	/** The name of this Function.**/
 	private String functionName;
-	
+	/** intstance to create Events for this FunctionBlock. **/
+	private static CustomGesture cg;
+		
 	/**
 	 * Method that creates a newInstance of this class along with it's visual representation
 	 * @param the number of arguments this FunctionBlock can hold
 	 * @return a new instance of this class
 	 * @throws IOException
 	 */
-	public static FunctionBlock newInstance(int numberOfArguments) throws IOException {
+	public static FunctionBlock newInstance(int numberOfArguments, CustomUIPane pane) throws IOException {
 		FunctionBlock functionBlock = (FunctionBlock) FXMLLoader.load(Main.class.getResource("/ui/FunctionBlock.fxml"), null, new TactileBuilderFactory());
 		functionBlock.initializeArguments(numberOfArguments);
-
+		cg = new CustomGesture(functionBlock, functionBlock);
+		cup = pane;
 		return functionBlock;
 	}
 	
@@ -44,8 +52,8 @@ public class FunctionBlock extends Block {
 	 * @return a new instance of this class
 	 * @throws IOException
 	 */
-	public static FunctionBlock newInstance(int numberOfArguments, String name) throws IOException {
-		FunctionBlock functionBlock = newInstance(numberOfArguments);
+	public static FunctionBlock newInstance(int numberOfArguments, CustomUIPane pane, String name) throws IOException {
+		FunctionBlock functionBlock = newInstance(numberOfArguments, pane);
 		functionBlock.setName(name);
 		
 		return functionBlock;

--- a/Code/src/main/java/nl/utwente/group10/ui/gestures/CustomGesture.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/gestures/CustomGesture.java
@@ -6,6 +6,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import nl.utwente.group10.ui.CustomUIPane;
+import nl.utwente.group10.ui.gestures.*;
 import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.input.MouseEvent;
@@ -16,6 +17,7 @@ public class CustomGesture implements EventHandler<MouseEvent> {
 	private GestureCallBack callBack;
 	private long startTime;
 	private Date date = new Date();
+	private boolean draggedWhilePressed;
 
 	public CustomGesture(GestureCallBack callBack, Node latchTo) {
 		this.callBack = callBack;
@@ -30,15 +32,21 @@ public class CustomGesture implements EventHandler<MouseEvent> {
 		if (event.getEventType().equals(MouseEvent.MOUSE_RELEASED)) {
 			if ((System.currentTimeMillis() - startTime) < 500) {
 
-				callBack.handleCustomEvent(new CustomGestureEvent(
-						CustomGestureEvent.TAP));
-				System.out.println("CustomGesture -> CustomGestureEvent.TAP");
+				callBack.handleCustomEvent(new UIEvent(UIEvent.TAP));
+				System.out.println("CustomGesture -> UIEvent.TAP");
 			} else {
-				callBack.handleCustomEvent(new CustomGestureEvent(
-						CustomGestureEvent.TAP_HOLD));
-				System.out
-						.println("CustomGesture -> CustomGestureEvent.TAP_HOLD");
+				if(!draggedWhilePressed){
+					callBack.handleCustomEvent(new UIEvent(UIEvent.TAP_HOLD));
+					System.out.println("CustomGesture -> UIEvent.TAP_HOLD");
+				} else {
+					callBack.handleCustomEvent(new UIEvent(UIEvent.DRAG));
+					System.out.println("CustomGesture -> UIEvent.DRAG");
+					draggedWhilePressed = false;
+				}
 			}
+		}
+		if (event.getEventType().equals(MouseEvent.MOUSE_DRAGGED)){
+			draggedWhilePressed = true;
 		}
 	}
 

--- a/Code/src/main/java/nl/utwente/group10/ui/gestures/GestureCallBack.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/gestures/GestureCallBack.java
@@ -2,5 +2,5 @@ package nl.utwente.group10.ui.gestures;
 
 public interface GestureCallBack {
 
-	public void handleCustomEvent(CustomGestureEvent event);
+	public void handleCustomEvent(UIEvent event);
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/gestures/UIEvent.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/gestures/UIEvent.java
@@ -1,19 +1,36 @@
 package nl.utwente.group10.ui.gestures;
 
+
+import javafx.event.Event;
 import javafx.event.EventType;
 import javafx.scene.Node;
 import nl.utwente.ewi.caes.tactilefx.event.TactilePaneEvent;
 
-public class UIEvent extends TactilePaneEvent {
-
-	//TODO merge with CustomGestureEvent
+public class UIEvent extends Event {	
 	
-	
+	public static final EventType<UIEvent> ANY = new EventType<>(Event.ANY, "ANY");
 	public static final EventType<UIEvent> TAP = new EventType<>(ANY, "TAP");
 	public static final EventType<UIEvent> TAP_HOLD = new EventType<>(ANY, "TAP_HOLD");
+	public static final EventType<UIEvent> DRAG = new EventType<>(ANY, "DRAG");
+	private EventType<UIEvent> eventType;
 	
-	public UIEvent(EventType<TactilePaneEvent> eventType, Node target, Node otherNode){
-		super(eventType, target, otherNode);
+	public UIEvent(EventType<UIEvent> eventType){
+		super(eventType);
+		this.eventType = eventType;
 	}
 	
+	@Override
+	public String toString() {
+		String result;
+		if (eventType.equals(ANY)) {
+			result = "CustomGestureEvent type = ANY";
+		} else if (eventType.equals(TAP)) {
+			result = "CustomGestureEvent type = TAP";
+		} else if (eventType.equals(TAP_HOLD)) {
+			result = "CustomGestureEvent type = TAP_HOLD";
+		} else {
+			result = "Nog niet opgenomen CustomGestureEvent";
+		}
+		return result;
+	}
 }


### PR DESCRIPTION
CustomGestureEvent wordt niet meer gebruikt. In plaats hiervan is dit nu UIEvent. De code is echter hetzelfde gebleven. Verder vangt (Function)Block nu ook events af en houdt een (Function)Block bij in welke CustomUIPane deze zit i.v.m. het selecteren van ander (Function)Blocks.
Een (Function)Block kan nu geselecteerd worden door er op te klikken. Bij het klikken op een ander (Function)Block vervalt een eventuele andere selectie