### PR TITLE
Demonstrate JavaFX data binding

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -1,12 +1,16 @@
 package nl.utwente.group10.ui.components;
 
+import javafx.fxml.Initializable;
 import javafx.scene.layout.StackPane;
+
+import java.net.URL;
+import java.util.ResourceBundle;
 
 /**
  * Base UI Component that other visual elements will extend from.
  * If common functionality is found it should be refactored to here.
  */
-public class Block extends StackPane {
+public class Block extends StackPane implements Initializable {
 
 	/** Selected state of this Block*/
 	private boolean isSelected = false;
@@ -18,5 +22,9 @@ public class Block extends StackPane {
 	public void setSelected(boolean selectedState) {
 		//TODO If another object is selected then deselect it first!!
 		isSelected = selectedState;
+	}
+
+	@Override
+	public void initialize(URL location, ResourceBundle resources) {
 	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -1,17 +1,13 @@
 package nl.utwente.group10.ui.components;
 
-import java.io.IOException;
-
-import nl.utwente.ewi.caes.tactilefx.fxml.TactileBuilderFactory;
-import nl.utwente.group10.ui.Main;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
-import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.StackPane;
-import javafx.scene.control.Label;
-import javafx.scene.shape.Rectangle;
+
+import java.io.IOException;
 
 /**
  * Main building block for the visual interface, this class
@@ -21,34 +17,31 @@ import javafx.scene.shape.Rectangle;
 public class FunctionBlock extends Block {
 	/** The arguments this FunctionBlock holds.**/
 	private String[] arguments;
-	/** The name of this Function.**/
-	private String functionName;
-	
-	/**
-	 * Method that creates a newInstance of this class along with it's visual representation
-	 * @param the number of arguments this FunctionBlock can hold
-	 * @return a new instance of this class
-	 * @throws IOException
-	 */
-	public static FunctionBlock newInstance(int numberOfArguments) throws IOException {
-		FunctionBlock functionBlock = (FunctionBlock) FXMLLoader.load(Main.class.getResource("/ui/FunctionBlock.fxml"), null, new TactileBuilderFactory());
-		functionBlock.initializeArguments(numberOfArguments);
 
-		return functionBlock;
+	/** The name of this Function. **/
+	private StringProperty name;
+
+	/** The type of this Function. **/
+	private StringProperty type;
+
+	@FXML
+	private Pane nestSpace;
+
+	public FunctionBlock(int numArgs) throws IOException {
+		FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("/ui/FunctionBlock.fxml"));
+		fxmlLoader.setRoot(this);
+		fxmlLoader.setController(this);
+
+		name = new SimpleStringProperty("Function name");
+		type = new SimpleStringProperty("Function type");
+
+		initializeArguments(numArgs);
+
+		fxmlLoader.load();
 	}
-	
-	/**
-	 * Method that creates a newInstance of this class along with it's visual representation
-	 * @param the number of arguments this FunctionBlock can hold
-	 * @param the name of this FunctionBlock
-	 * @return a new instance of this class
-	 * @throws IOException
-	 */
-	public static FunctionBlock newInstance(int numberOfArguments, String name) throws IOException {
-		FunctionBlock functionBlock = newInstance(numberOfArguments);
-		functionBlock.setName(name);
-		
-		return functionBlock;
+
+	public static FunctionBlock newInstance(int numArgs) throws IOException {
+		return new FunctionBlock(numArgs);
 	}
 	
 	/**
@@ -64,8 +57,7 @@ public class FunctionBlock extends Block {
 	 * @param node to nest
 	 */
 	public void nest(Node node) {
-		Pane nestSpace = (Pane) this.lookup("#nest_space");
-		((Label) this.lookup("#label_function_name")).setText("Higher order function");
+		name.set("Higher order function");
 		nestSpace.getChildren().add(node);
 	}
 	
@@ -81,20 +73,24 @@ public class FunctionBlock extends Block {
 	
 	/**
 	 * Method to set the value of a specified argument
-	 * @param the index of the argument field
-	 * @param the value that the argument should be changed to
 	 */
 	public void setArgument(int i,String arg) {
 		arguments[i] = arg;
 	}
+
+	public String getName() {
+		return name.get();
+	}
 	
-	/**
-	 * Method to set the name of this FunctionBlock
-	 * @param name
-	 */
 	public void setName(String name) {
-		functionName = name;
-		Label label = ((Label)this.lookup("#label_function_name"));
-		label.setText(functionName);
+		this.name.set(name);
+	}
+
+	public String getType() {
+		return type.get();
+	}
+
+	public void setType(String type) {
+		this.type.set(type);
 	}
 }

--- a/Code/src/main/resources/ui/FunctionBlock.fxml
+++ b/Code/src/main/resources/ui/FunctionBlock.fxml
@@ -1,28 +1,20 @@
-<?import nl.utwente.group10.ui.components.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import java.net.*?>
 
-
-<FunctionBlock xmlns:fx="http://javafx.com/fxml/1" styleClass="block">
-	<BorderPane id="foreground" minHeight="90" minWidth="180">
+<fx:root type="nl.utwente.group10.ui.components.FunctionBlock" xmlns:fx="http://javafx.com/fxml/1" styleClass="function, block">
+	<BorderPane minHeight="90" minWidth="180">
 		<top>
 			<BorderPane>
 				<top>
-					<Label id="label_function_name" text="Function name"
-						styleClass="functionBlockTitle" />
+					<Label text="${controller.name}" styleClass="title" />
 				</top>
 				<bottom>
-					<Label id="label_function_type" text="Function type"
-						styleClass="functionBlockDescription" />
+					<Label text="${controller.type}" styleClass="description" />
 				</bottom>
 			</BorderPane>
 		</top>
 		<center>
-			<FlowPane id="nest_space" styleClass="functionBlockNestSpace" prefWrapLength="100" vgap="5"/>
+			<FlowPane fx:id="nestSpace" styleClass="nestSpace" prefWrapLength="100" vgap="5"/>
 		</center>
 	</BorderPane>
-	<stylesheets>
-		<URL value="@style.css" />
-	</stylesheets>
-</FunctionBlock>
+</fx:root>

--- a/Code/src/main/resources/ui/style.css
+++ b/Code/src/main/resources/ui/style.css
@@ -1,26 +1,16 @@
 .block {
 	-fx-font-size: 20px;
 	-fx-font-weight: bold;
-	-fx-background-color:aliceblue;
+	-fx-background-color: gray;
 	-fx-border-color: black;
 	-fx-border-width: 2;
 }
-.functionBlockBackground {
-	-fx-text-fill: #333333;
-	-fx-fill: aliceblue;
-	-fx-stroke: black;
-	-fx-stroke-width: 2;
-}
-.functionBlockTitle {
-	-fx-font-size: 20px;
-	-fx-font-weight: bold;
-	-fx-padding: 0 0 2 5;
-}
-.functionBlockDescription {
+
+.function.block .description {
 	-fx-font-size: 12px;
 	-fx-padding: 0;
 }
-.functionBlockNestSpace {
+.function.block .nestSpace {
 	-fx-padding: 15;
 }
 
@@ -32,6 +22,6 @@
 	-fx-background-color: #c0392b;
 }
 
-.value.block .title, .display.block .title {
+.block .title {
 	-fx-text-fill: #ecf0f1;
 }


### PR DESCRIPTION
Hello hello,

I noticed some hardcore manual setting of properties going on in frontend stuff so far. This is not a problem in and out of itself, however, JavaFX also has some data binding features which could be of use. Specifically:

- JavaFX can inject parts of the interface for you by `fx:id`. This replaces `lookup` and friends.
- JavaFX can observe (!) properties from your class and use those as attributes. This replaces `setText` et al.

This has a few advantages:

- No duplicate state: for example, the function name is now stored in one place, not copied from the FunctionBlock to the corresponding label.
- Decoupling: want to add another label with the same content? Easy.
- No need to remember doing `setText()` calls or anything.
- The FXML is a bit simpler and shorter.
- No need to do calls to `this.lookup`. These calls need an (ugly!) cast to do what you want, and they're probably slow besides, as they have to walk through the entire component every time you do a lookup. Injecting happens once.

This PR is just a (runnable) demonstration/proof of concept; I'll close it right away. It is provided in the hope that it will be useful.

Cheers,
Wander