### PR TITLE
Fix JavaFX init thread for ValueBlockTest

### DIFF
--- a/Code/src/test/java/nl/utwente/group10/ui/components/ComponentTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/ComponentTest.java
@@ -28,11 +28,7 @@ public class ComponentTest {
     @BeforeClass
     public static void initJFX() {
         if (t == null) {
-            t = new Thread("JavaFX Init Thread") {
-                public void run() {
-                    Application.launch(MockApp.class);
-                }
-            };
+            t = new Thread(() -> Application.launch(MockApp.class));
             t.setDaemon(true);
             t.start();
         }

--- a/Code/src/test/java/nl/utwente/group10/ui/components/ComponentTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/ComponentTest.java
@@ -8,6 +8,8 @@ import org.junit.BeforeClass;
  * Superclass for component tests.
  */
 public class ComponentTest {
+    private static Thread t = null;
+
     /**
      * Test Application extension with voided start method
      * to enable setup of unit testing.
@@ -25,12 +27,14 @@ public class ComponentTest {
      */
     @BeforeClass
     public static void initJFX() {
-        Thread t = new Thread("JavaFX Init Thread") {
-            public void run() {
-                Application.launch(MockApp.class);
-            }
-        };
-        t.setDaemon(true);
-        t.start();
+        if (t == null) {
+            t = new Thread("JavaFX Init Thread") {
+                public void run() {
+                    Application.launch(MockApp.class);
+                }
+            };
+            t.setDaemon(true);
+            t.start();
+        }
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/ui/components/ValueBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/ValueBlockTest.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class ValueBlockTest {
+public class ValueBlockTest extends ComponentTest {
     @Test
     public void initTest() throws IOException {
         assertNotNull(ValueBlock.newInstance("6"));


### PR DESCRIPTION
The JavaFX Init thread was not created for the ValueBlockTest, which
meant it only passed if it happened to be run after the
DisplayBlockTest. This commit resolves that problem.

It also ensures no more than one such thread is ever created.