### PR TITLE
Add more math functions to the catalog

### DIFF
--- a/Code/src/main/resources/catalog/functions.xml
+++ b/Code/src/main/resources/catalog/functions.xml
@@ -2,46 +2,46 @@
 <?xml-stylesheet type="text/xsl" href="functions.xsl" ?>
 <catalog>
     <category name="Math">
-		<function name="(*)" signature="Float -> Float -> Float"></function>
-		<function name="(+)" signature="Float -> Float -> Float"></function>
-		<function name="(-)" signature="Float -> Float -> Float"></function>
-		<function name="(/)" signature="Float -> Float -> Float"></function>
-		<function name="(/=)" signature="Float -> Float -> Bool"></function>
+        <function name="(*)" signature="Float -> Float -> Float"></function>
+        <function name="(+)" signature="Float -> Float -> Float"></function>
+        <function name="(-)" signature="Float -> Float -> Float"></function>
+        <function name="(/)" signature="Float -> Float -> Float"></function>
+        <function name="(/=)" signature="Float -> Float -> Bool"></function>
 
-		<function name="(^)" signature="Float -> Float -> Float"></function>
+        <function name="(^)" signature="Float -> Float -> Float"></function>
 
-		<function name="(<)" signature="Float -> Float -> Bool"></function>
-		<function name="(==)" signature="Float -> Float -> Bool"></function>
-		<function name="(>)" signature="Float -> Float -> Bool"></function>
+        <function name="(<)" signature="Float -> Float -> Bool"></function>
+        <function name="(==)" signature="Float -> Float -> Bool"></function>
+        <function name="(>)" signature="Float -> Float -> Bool"></function>
 
-		<function name="abs" signature="Float -> Float"></function>
-		<function name="acos" signature="Float -> Float"></function>
-		<function name="acosh" signature="Float -> Float"></function>
-		<function name="asin" signature="Float -> Float"></function>
-		<function name="asinh" signature="Float -> Float"></function>
-		<function name="atan" signature="Float -> Float"></function>
-		<function name="atanh" signature="Float -> Float"></function>
-		<function name="ceiling" signature="Float -> Float"></function>
-		<function name="cos" signature="Float -> Float"></function>
-		<function name="cosh" signature="Float -> Float"></function>
-		<function name="exp" signature="Float -> Float"></function>
-		<function name="floor" signature="Float -> Float"></function>
-		<function name="log" signature="Float -> Float"></function>
-		<function name="logBase" signature="Float -> Float -> Float"></function>
-		<function name="negate" signature="Float -> Float"></function>
-		<function name="pred" signature="Float -> Float"></function>
-		<function name="recip" signature="Float -> Float"></function>
-		<function name="round" signature="Float -> Float"></function>
-		<function name="signum" signature="Float -> Float"></function>
-		<function name="sin" signature="Float -> Float"></function>
-		<function name="sinh" signature="Float -> Float"></function>
-		<function name="sqrt" signature="Float -> Float"></function>
-		<function name="succ" signature="Float -> Float"></function>
-		<function name="tan" signature="Float -> Float"></function>
-		<function name="tanh" signature="Float -> Float"></function>
-		<function name="truncate" signature="Float -> Float"></function>
+        <function name="abs" signature="Float -> Float"></function>
+        <function name="acos" signature="Float -> Float"></function>
+        <function name="acosh" signature="Float -> Float"></function>
+        <function name="asin" signature="Float -> Float"></function>
+        <function name="asinh" signature="Float -> Float"></function>
+        <function name="atan" signature="Float -> Float"></function>
+        <function name="atanh" signature="Float -> Float"></function>
+        <function name="ceiling" signature="Float -> Float"></function>
+        <function name="cos" signature="Float -> Float"></function>
+        <function name="cosh" signature="Float -> Float"></function>
+        <function name="exp" signature="Float -> Float"></function>
+        <function name="floor" signature="Float -> Float"></function>
+        <function name="log" signature="Float -> Float"></function>
+        <function name="logBase" signature="Float -> Float -> Float"></function>
+        <function name="negate" signature="Float -> Float"></function>
+        <function name="pred" signature="Float -> Float"></function>
+        <function name="recip" signature="Float -> Float"></function>
+        <function name="round" signature="Float -> Float"></function>
+        <function name="signum" signature="Float -> Float"></function>
+        <function name="sin" signature="Float -> Float"></function>
+        <function name="sinh" signature="Float -> Float"></function>
+        <function name="sqrt" signature="Float -> Float"></function>
+        <function name="succ" signature="Float -> Float"></function>
+        <function name="tan" signature="Float -> Float"></function>
+        <function name="tanh" signature="Float -> Float"></function>
+        <function name="truncate" signature="Float -> Float"></function>
 
-		<function name="pi" signature="Float"></function>
+        <function name="pi" signature="Float"></function>
     </category>
     <category name="Maps, folds and lists">
         <function name="head" signature="[a] -> a">

--- a/Code/src/main/resources/catalog/functions.xml
+++ b/Code/src/main/resources/catalog/functions.xml
@@ -10,7 +10,7 @@
 
         <function name="(^)" signature="Float -> Float -> Float"></function>
 
-        <function name="(<)" signature="Float -> Float -> Bool"></function>
+        <function name="(&lt;)" signature="Float -> Float -> Bool"></function>
         <function name="(==)" signature="Float -> Float -> Bool"></function>
         <function name="(>)" signature="Float -> Float -> Bool"></function>
 

--- a/Code/src/main/resources/catalog/functions.xml
+++ b/Code/src/main/resources/catalog/functions.xml
@@ -2,9 +2,46 @@
 <?xml-stylesheet type="text/xsl" href="functions.xsl" ?>
 <catalog>
     <category name="Math">
-        <function name="(+)" signature="a -> a -> a">
-            Adds two numbers.
-        </function>
+		<function name="(*)" signature="Float -> Float -> Float"></function>
+		<function name="(+)" signature="Float -> Float -> Float"></function>
+		<function name="(-)" signature="Float -> Float -> Float"></function>
+		<function name="(/)" signature="Float -> Float -> Float"></function>
+		<function name="(/=)" signature="Float -> Float -> Bool"></function>
+
+		<function name="(^)" signature="Float -> Float -> Float"></function>
+
+		<function name="(<)" signature="Float -> Float -> Bool"></function>
+		<function name="(==)" signature="Float -> Float -> Bool"></function>
+		<function name="(>)" signature="Float -> Float -> Bool"></function>
+
+		<function name="abs" signature="Float -> Float"></function>
+		<function name="acos" signature="Float -> Float"></function>
+		<function name="acosh" signature="Float -> Float"></function>
+		<function name="asin" signature="Float -> Float"></function>
+		<function name="asinh" signature="Float -> Float"></function>
+		<function name="atan" signature="Float -> Float"></function>
+		<function name="atanh" signature="Float -> Float"></function>
+		<function name="ceiling" signature="Float -> Float"></function>
+		<function name="cos" signature="Float -> Float"></function>
+		<function name="cosh" signature="Float -> Float"></function>
+		<function name="exp" signature="Float -> Float"></function>
+		<function name="floor" signature="Float -> Float"></function>
+		<function name="log" signature="Float -> Float"></function>
+		<function name="logBase" signature="Float -> Float -> Float"></function>
+		<function name="negate" signature="Float -> Float"></function>
+		<function name="pred" signature="Float -> Float"></function>
+		<function name="recip" signature="Float -> Float"></function>
+		<function name="round" signature="Float -> Float"></function>
+		<function name="signum" signature="Float -> Float"></function>
+		<function name="sin" signature="Float -> Float"></function>
+		<function name="sinh" signature="Float -> Float"></function>
+		<function name="sqrt" signature="Float -> Float"></function>
+		<function name="succ" signature="Float -> Float"></function>
+		<function name="tan" signature="Float -> Float"></function>
+		<function name="tanh" signature="Float -> Float"></function>
+		<function name="truncate" signature="Float -> Float"></function>
+
+		<function name="pi" signature="Float"></function>
     </category>
     <category name="Maps, folds and lists">
         <function name="head" signature="[a] -> a">


### PR DESCRIPTION
This adds some Float-specialized variants of Haskell's prelude math functions
to the catalog. (The signatures are specialized because type classes aren't
supported yet.)