### PR TITLE
Add a short blurb about type checker to report

### DIFF
--- a/Report/.gitignore
+++ b/Report/.gitignore
@@ -13,3 +13,5 @@
 *.idx
 *.ilg
 *.ind
+*.bbl
+*.blg

--- a/Report/Chapters/Bibliography.bib
+++ b/Report/Chapters/Bibliography.bib
@@ -1,8 +1,30 @@
+@misc{forrest,
+	author = {Andrew Forrest},
+	title = {{H}indley-{M}ilner type inference in {S}cala},
+	note = {\url{https://dysphoria.net/2009/06/28/hindley-milner-type-inference-in-scala/}},
+	year = {2009}
+}
+
+@misc{borisov,
+	author = {Nikita Borisov},
+	title = {The {H}indley-{M}ilner Algorithm},
+	note = {\url{http://www.cs.berkeley.edu/~nikitab/courses/cs263/hm.html}},
+	year = {2005}
+}
+
 @article{cardelli,
     author = {Luca Cardelli},
     title = {Basic polymorphic typechecking},
     journal = {Science of Computer Programming},
+    note = {\url{http://lucacardelli.name/Papers/BasicTypechecking.pdf}},
     year = {1987},
     volume = {8},
     pages = {147--172}
+}
+
+@book{plai,
+	author = {Shriram Krishnamurthi},
+	title = {Programming languages - application and interpretation},
+	year = {2003},
+	note = {\url{http://www.cs.brown.edu/~sk/Publications/Books/ProgLangs/}}
 }

--- a/Report/Chapters/Bibliography.bib
+++ b/Report/Chapters/Bibliography.bib
@@ -1,0 +1,8 @@
+@article{cardelli,
+    author = {Luca Cardelli},
+    title = {Basic polymorphic typechecking},
+    journal = {Science of Computer Programming},
+    year = {1987},
+    volume = {8},
+    pages = {147--172}
+}

--- a/Report/Chapters/Bibliography.tex
+++ b/Report/Chapters/Bibliography.tex
@@ -1,6 +1,0 @@
-\bibitem{lamport94}
-  Leslie Lamport,
-  \emph{LaTeX: a document preparation system}.
-  Addison Wesley, Massachusetts,
-  2nd edition,
-  1994.

--- a/Report/Chapters/Glossary.tex
+++ b/Report/Chapters/Glossary.tex
@@ -37,3 +37,13 @@
 	name={function block},
 	description={A visual block representing a haskell function}
 }
+
+\newglossaryentry{GHC}{
+	name={Glasgow Haskell Compiler},
+	description={A popular and actively-developed Haskell compiler toolchain, and base of the official Haskell Platform, see \url{http://haskell.org/ghc}}
+}
+
+\newglossaryentry{REPL}{
+	name={read-eval-print-loop},
+	description={An interactive (usually command-line) interface that allows executing programming language expressions without having to do an intermediate compilation step}
+}

--- a/Report/Chapters/Implementation.tex
+++ b/Report/Chapters/Implementation.tex
@@ -1,2 +1,32 @@
 \chapter{Implementation}
 
+\section{Front end}
+
+\section{Back end}
+
+\subsection{GHC integration}
+
+The front end enables the user to construct Haskell expressions in a convenient manner.
+The visual representation is converted into a tree of expression (Expr) objects and passed to the back end. \index{Expr}
+The back end, finally, integrates with the Glasgow Haskell Compiler (\gls{GHC}) to do the actual computation.
+
+The GHC integration is very simplistic.
+The back end launches an instance of GHCi, the interactive read-eval-print-loop. \index{REPL}
+This \gls{REPL} is then drip-fed the expressions over its standard input stream, converted from the intermediate representation into actual Haskell program code.
+If the expression compiles and executes without problems, the result is returned to the front end.
+
+\subsection{Type checker}
+
+From our own experience as beginning Haskell programmers, we often encountered type errors, and therefore GHC's type error messages.
+Very early in the project, we decided that the back end had to do at least some type-related work itself, to provide better errors to the user, and also to be able to show type hints, without having to parse GHC's error messages.
+Not long thereafter, it was decided that such a home-grown type checker would not need to support the entirety of Haskell's type system.
+
+After some iterations, we have arrived at an approach that could probably be described as a subset of Hindley-Milner type inference. \index{Hindley-Milner} \index{type inference}
+
+Our (Java) implementation of Hindley-Milner type inference is based on an implementation in Scala by Andrew Forrest\cite{forrest}.
+This implementation was in turn based on an implementation in Perl by Nikita Borisov\cite{borisov}.
+The Perl implementation was heavily inspired by a Modula-2 implementation from 1987 by Luca Cardelli\cite{cardelli}.
+Some ideas were also taken from the chapter on types from the programming languages book by Krishnamurthi\cite{plai}.
+
+As mentioned, the type checker is not nearly powerful enough to understand or even represent the entire complexity of Haskell's type system.
+However, we have found it to be `good enough' for our purposes.

--- a/Report/Chapters/Preface.tex
+++ b/Report/Chapters/Preface.tex
@@ -1,5 +1,1 @@
 \chapter{Preface}
-
-This is a report on the care and nurturing of a \gls{banana}.
-Bananas are yellow. \index{banana, color}
-Even Leslie Lamport thinks bananas are yellow \cite{cardelli}.

--- a/Report/Chapters/Preface.tex
+++ b/Report/Chapters/Preface.tex
@@ -2,4 +2,4 @@
 
 This is a report on the care and nurturing of a \gls{banana}.
 Bananas are yellow. \index{banana, color}
-Even Leslie Lamport thinks bananas are yellow \cite{lamport94}.
+Even Leslie Lamport thinks bananas are yellow \cite{cardelli}.

--- a/Report/report.tex
+++ b/Report/report.tex
@@ -10,6 +10,7 @@
 \usepackage{titling}
 \usepackage{imakeidx}
 \usepackage{parskip}
+\usepackage{cite}
 \usepackage[nottoc]{tocbibind}
 \usepackage[hidelinks]{hyperref}
 \usepackage[toc,section=chapter]{glossaries}
@@ -64,9 +65,8 @@
 
 \include{Chapters/Recommendations}
 
-\begin{thebibliography}{999}
-\input{Chapters/Bibliography}
-\end{thebibliography}
+\bibliography{Chapters/Bibliography}{}
+\bibliographystyle{unsrt}
 
 \printindex
 

--- a/Report/report.tex
+++ b/Report/report.tex
@@ -11,6 +11,7 @@
 \usepackage{imakeidx}
 \usepackage{parskip}
 \usepackage{cite}
+\usepackage{url}
 \usepackage[nottoc]{tocbibind}
 \usepackage[hidelinks]{hyperref}
 \usepackage[toc,section=chapter]{glossaries}
@@ -34,6 +35,7 @@
 
 \renewcommand*\rmdefault{ppl}
 \renewcommand*\sfdefault{ppl}
+\urlstyle{same}
 
 \begin{titlepage}
 	{\Huge \thetitle} \\
@@ -65,8 +67,8 @@
 
 \include{Chapters/Recommendations}
 
-\bibliography{Chapters/Bibliography}{}
 \bibliographystyle{unsrt}
+\bibliography{Chapters/Bibliography}
 
 \printindex
 


### PR DESCRIPTION
This PR adds a short blurb about the type checker to the report.

It also changes the bibliography system to use the more convenient BibTeX and adds some useful sources.