### PR TITLE
Add basic calculator functionality

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ghcj/GhciSession.java
+++ b/Code/src/main/java/nl/utwente/group10/ghcj/GhciSession.java
@@ -15,7 +15,7 @@ public class GhciSession implements Closeable {
     private final GhciEvaluator ghci;
 
     /** Singleton instance. */
-    private static Optional<GhciSession> instance;
+    private static Optional<GhciSession> instance = Optional.empty();
 
     /**
      * Builds a new communication session with ghci.

--- a/Code/src/main/java/nl/utwente/group10/ghcj/GhciSession.java
+++ b/Code/src/main/java/nl/utwente/group10/ghcj/GhciSession.java
@@ -5,6 +5,7 @@ import nl.utwente.group10.haskell.expr.*;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * A conversation with an instance of ghci.
@@ -13,13 +14,16 @@ public class GhciSession implements Closeable {
     /** The evaluator this GhciSession will communicate with. */
     private final GhciEvaluator ghci;
 
+    /** Singleton instance. */
+    private static Optional<GhciSession> instance;
+
     /**
      * Builds a new communication session with ghci.
      *
      * @throws GhciException when ghci can not be found, can not be executed,
      *         or does not understand our setup sequence.
      */
-    public GhciSession() throws GhciException {
+    private GhciSession() throws GhciException {
         this.ghci = new GhciEvaluator();
     }
 
@@ -53,5 +57,13 @@ public class GhciSession implements Closeable {
     @Override
     public void close() throws IOException {
         this.ghci.close();
+    }
+
+    public static GhciSession getInstance() throws GhciException {
+        if (!instance.isPresent()) {
+            instance = Optional.of(new GhciSession());
+        }
+
+        return instance.get();
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/haskell/catalog/Entry.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/catalog/Entry.java
@@ -4,7 +4,7 @@ import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.haskell.typeparser.TypeBuilder;
 
 /** A function entry in the Haskell catalog. */
-public class Entry {
+public class Entry implements Comparable<Entry> {
     /** The name of this Entry. */
     private final String name;
 
@@ -66,5 +66,10 @@ public class Entry {
     public final Type getType() {
         TypeBuilder builder = new TypeBuilder();
         return builder.build(this.getSignature());
+    }
+
+    @Override
+    public int compareTo(Entry entry) {
+        return this.getName().compareTo(entry.getName());
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/haskell/catalog/HaskellCatalog.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/catalog/HaskellCatalog.java
@@ -1,7 +1,7 @@
 package nl.utwente.group10.haskell.catalog;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.TreeMultimap;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.CatalogException;
 import org.w3c.dom.Document;
@@ -23,7 +23,7 @@ import java.util.*;
  */
 public class HaskellCatalog {
     /** Map from category to entry for use in getCategories and getCategory. */
-    private final Multimap<String, Entry> byCategory;
+    private final TreeMultimap<String, Entry> byCategory;
 
     /** Map from function name to entry for use in get() and friends. */
     private final Map<String, Entry> byName;
@@ -51,8 +51,8 @@ public class HaskellCatalog {
         URL functions = HaskellCatalog.class.getResource(path);
         URL xmlschema = HaskellCatalog.class.getResource(XSD_PATH);
 
-        this.byName = new HashMap<String, Entry>();
-        this.byCategory = HashMultimap.create();
+        this.byName = new HashMap<>();
+        this.byCategory = TreeMultimap.create();
 
         try {
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -1,6 +1,8 @@
 package nl.utwente.group10.ui;
 
+import javafx.scene.Node;
 import nl.utwente.ewi.caes.tactilefx.control.TactilePane;
+import nl.utwente.group10.ui.components.DisplayBlock;
 import nl.utwente.group10.ui.components.OutputAnchor;
 import nl.utwente.group10.ui.gestures.UIEvent;
 import nl.utwente.group10.ui.gestures.GestureCallBack;
@@ -24,5 +26,14 @@ public class CustomUIPane extends TactilePane implements GestureCallBack {
 
 	@Override
 	public void handleCustomEvent(UIEvent event) {
+	}
+
+	/** Re-evaluate all displays. */
+	public void invalidate() {
+		for (Node node : getChildren()) {
+			if (node instanceof DisplayBlock) {
+				((DisplayBlock)node).invalidate();
+			}
+		}
 	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -1,14 +1,25 @@
 package nl.utwente.group10.ui;
 
-import javafx.event.EventType;
 import nl.utwente.ewi.caes.tactilefx.control.TactilePane;
-import nl.utwente.group10.ui.gestures.CustomGesture;
+import nl.utwente.group10.ui.components.OutputAnchor;
 import nl.utwente.group10.ui.gestures.UIEvent;
 import nl.utwente.group10.ui.gestures.GestureCallBack;
 
+import java.util.Optional;
+
 public class CustomUIPane extends TactilePane implements GestureCallBack {
+	private Optional<OutputAnchor> anchor;
 
 	public CustomUIPane() {
+		this.anchor = Optional.empty();
+	}
+
+	public void setLastOutputAnchor(OutputAnchor anchor) {
+		this.anchor = Optional.ofNullable(anchor);
+	}
+
+	public Optional<OutputAnchor> getLastOutputAnchor() {
+		return this.anchor;
 	}
 
 	@Override

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -64,7 +64,7 @@ public class Main extends Application {
 		debug.registerTactilePane(tactilePane);
 
 		Scene scene = new Scene(debug);
-		stage.setOnCloseRequest(event -> Platform.exit());
+		stage.setOnCloseRequest(event -> System.exit(0));
 		stage.setScene(scene);
 		stage.show();
 

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -2,7 +2,6 @@ package nl.utwente.group10.ui;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
-import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.CheckMenuItem;
@@ -70,7 +69,7 @@ public class Main extends Application {
 		stage.show();
 
 		// Invalidate
-		invalidate();
+		tactilePane.invalidate(this);
 	}
 
 	private void addFunctionBlock(Entry entry) {
@@ -88,15 +87,6 @@ public class Main extends Application {
 		alert.setHeaderText("An unexpected error occurred.");
 		alert.setContentText(String.format("%s", e));
 		alert.showAndWait();
-	}
-
-	/** Re-evaluate all displays. */
-	private void invalidate() {
-		for (Node node : tactilePane.getChildren()) {
-			if (node instanceof DisplayBlock) {
-				((DisplayBlock)node).invalidate();
-			}
-		}
 	}
 
 	public static void main(String[] args) {

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -30,7 +30,7 @@ public class Main extends Application {
 
 		HaskellCatalog catalog = new HaskellCatalog();
 
-		tactilePane.getChildren().add(new ValueBlock("6.0"));
+		tactilePane.getChildren().add(new ValueBlock(tactilePane));
 		tactilePane.getChildren().add(new DisplayBlock(tactilePane));
 
 		// Init Debug

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -3,7 +3,6 @@ package nl.utwente.group10.ui;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
-import javafx.scene.control.Alert;
 import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Menu;

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -3,6 +3,7 @@ package nl.utwente.group10.ui;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.CheckBox;
 import javafx.scene.layout.BorderPane;
@@ -18,13 +19,14 @@ import nl.utwente.group10.ui.components.FunctionBlock;
 import nl.utwente.group10.ui.components.ValueBlock;
 
 public class Main extends Application {
-	DebugParent debug;
+	private DebugParent debug;
+	private CustomUIPane tactilePane;
 
 	@Override
 	public void start(Stage stage) throws Exception {
 		BorderPane root = new BorderPane();
 
-		CustomUIPane tactilePane = FXMLLoader.load(this.getClass().getResource("/ui/Main.fxml"), null, new TactileBuilderFactory());
+		tactilePane = FXMLLoader.load(this.getClass().getResource("/ui/Main.fxml"), null, new TactileBuilderFactory());
 
 		HaskellCatalog catalog = new HaskellCatalog();
 
@@ -65,6 +67,18 @@ public class Main extends Application {
 		stage.setOnCloseRequest(event -> Platform.exit());
 		stage.setScene(scene);
 		stage.show();
+
+		// Invalidate
+		invalidate();
+	}
+
+	/** Re-evaluate all displays. */
+	private void invalidate() {
+		for (Node node : tactilePane.getChildren()) {
+			if (node instanceof DisplayBlock) {
+				((DisplayBlock)node).invalidate();
+			}
+		}
 	}
 
 	public static void main(String[] args) {

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -31,7 +31,7 @@ public class Main extends Application {
 		HaskellCatalog catalog = new HaskellCatalog();
 
 		tactilePane.getChildren().add(new ValueBlock("6.0"));
-		tactilePane.getChildren().add(new DisplayBlock());
+		tactilePane.getChildren().add(new DisplayBlock(tactilePane));
 
 		// Init Debug
 		debug = new DebugParent(tactilePane);

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -77,16 +77,8 @@ public class Main extends Application {
 			FunctionBlock fb = new FunctionBlock(entry.getName(), entry.getType(), tactilePane);
 			tactilePane.getChildren().add(fb);
 		} catch (IOException e) {
-			panic(e);
+			e.printStackTrace();
 		}
-	}
-
-	private void panic(Exception e) {
-		Alert alert = new Alert(Alert.AlertType.ERROR);
-		alert.setTitle("Exception");
-		alert.setHeaderText("An unexpected error occurred.");
-		alert.setContentText(String.format("%s", e));
-		alert.showAndWait();
 	}
 
 	public static void main(String[] args) {

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -69,7 +69,7 @@ public class Main extends Application {
 		stage.show();
 
 		// Invalidate
-		tactilePane.invalidate(this);
+		tactilePane.invalidate();
 	}
 
 	private void addFunctionBlock(Entry entry) {

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -26,7 +26,7 @@ public abstract class Block extends StackPane implements Initializable, GestureC
 	private boolean isSelected = false;
 	
 	/** The output of this Block.**/
-	private ConnectionAnchor output;
+	private OutputAnchor output;
 	
 	/** The fxmlLoader responsible for loading the fxml of this Block.*/
 	private FXMLLoader fxmlLoader;
@@ -38,7 +38,7 @@ public abstract class Block extends StackPane implements Initializable, GestureC
 		fxmlLoader.setRoot(this);
 		fxmlLoader.setController(this);
 		
-		output = new ConnectionAnchor();
+		output = new OutputAnchor();
 		cup = pane;
 	}
 	

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -53,7 +53,7 @@ public abstract class Block extends StackPane implements Initializable, GestureC
 	/**
 	 * @return the output Anchor for this Block
 	 */
-	public ConnectionAnchor getOutputAnchor() {
+	public OutputAnchor getOutputAnchor() {
 		return output;
 	}
 	

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -38,7 +38,7 @@ public abstract class Block extends StackPane implements Initializable, GestureC
 		fxmlLoader.setRoot(this);
 		fxmlLoader.setController(this);
 		
-		output = new OutputAnchor();
+		output = new OutputAnchor(pane);
 		cup = pane;
 	}
 	

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -4,6 +4,7 @@ package nl.utwente.group10.ui.components;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
+import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.gestures.GestureCallBack;
 import nl.utwente.group10.ui.gestures.UIEvent;
@@ -21,7 +22,7 @@ import java.util.ResourceBundle;
  * If common functionality is found it should be refactored to here.
  */
 
-public class Block extends StackPane implements Initializable, GestureCallBack {
+public abstract class Block extends StackPane implements Initializable, GestureCallBack {
 	
 	/** Selected state of this Block*/
 	private boolean isSelected = false;
@@ -89,4 +90,9 @@ public class Block extends StackPane implements Initializable, GestureCallBack {
 			//TODO: open the quick-menu
 		}
 	}
+
+	/**
+	 * @return an expression that evaluates to what this block is.
+	 */
+	public abstract Expr asExpr();
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -38,7 +38,7 @@ public abstract class Block extends StackPane implements Initializable, GestureC
 		fxmlLoader.setRoot(this);
 		fxmlLoader.setController(this);
 		
-		output = new OutputAnchor(pane);
+		output = new OutputAnchor(this, pane);
 		cup = pane;
 	}
 	

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -1,17 +1,15 @@
 package nl.utwente.group10.ui.components;
 
 
-import javafx.fxml.FXML;
+import javafx.event.EventType;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
+import javafx.scene.Node;
+import javafx.scene.layout.StackPane;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.gestures.GestureCallBack;
 import nl.utwente.group10.ui.gestures.UIEvent;
-import javafx.event.EventType;
-import javafx.scene.Node;
-import javafx.scene.layout.Pane;
-import javafx.scene.layout.StackPane;
 
 import java.io.IOException;
 import java.net.URL;

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
@@ -27,28 +27,28 @@ public class Connection extends Line implements ChangeListener<Number> , Initial
 	/**
 	 * Method that creates a new instance of this class along with it's visual
 	 * representation. 
-	 * @param from Block to connect from.
-	 * @param fromAnchor Anchor to start from.
-	 * @param to Block to connect to.
+	 * @param from Anchor to start from.
 	 * @param toAnchor Anchor to end at.
 	 * @return a new instance of this class
 	 * @throws IOException
 	 */
-	public Connection(Block from, OutputAnchor fromAnchor, Block to, InputAnchor toAnchor) throws IOException {
+	public Connection(OutputAnchor from, InputAnchor to) throws IOException {
 		fxmlLoader = new FXMLLoader(getClass().getResource("/ui/Connection.fxml"));
 		fxmlLoader.setRoot(this);
 		fxmlLoader.setController(this);
 
-		from.layoutXProperty().addListener(this);
-		from.layoutYProperty().addListener(this);
+		from.getBlock().layoutXProperty().addListener(this);
+		from.getBlock().layoutYProperty().addListener(this);
 
-		to.layoutXProperty().addListener(this);
-		to.layoutYProperty().addListener(this);
+		to.getBlock().layoutXProperty().addListener(this);
+		to.getBlock().layoutYProperty().addListener(this);
 
-		this.setStartAnchor(fromAnchor);
-		this.setEndAnchor(toAnchor);
+		this.setStartAnchor(from);
+		this.setEndAnchor(to);
 		
 		fxmlLoader.load();
+
+		updateStartEndPositions();
 	}
 	
 	@Override

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
@@ -1,16 +1,13 @@
 package nl.utwente.group10.ui.components;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.ResourceBundle;
-
-import nl.utwente.ewi.caes.tactilefx.fxml.TactileBuilderFactory;
-import nl.utwente.group10.ui.Main;
-import nl.utwente.group10.ui.components.Line;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ResourceBundle;
 
 /**
  * This class represents a connection between two different FunctionBlocks. The

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
@@ -37,11 +37,14 @@ public class Connection extends Line implements ChangeListener<Number> , Initial
 		fxmlLoader.setRoot(this);
 		fxmlLoader.setController(this);
 
-		from.getBlock().layoutXProperty().addListener(this);
-		from.getBlock().layoutYProperty().addListener(this);
+		input = from.getBlock();
+		output = to.getBlock();
 
-		to.getBlock().layoutXProperty().addListener(this);
-		to.getBlock().layoutYProperty().addListener(this);
+		input.layoutXProperty().addListener(this);
+		input.layoutYProperty().addListener(this);
+
+		output.layoutXProperty().addListener(this);
+		output.layoutYProperty().addListener(this);
 
 		this.setStartAnchor(from);
 		this.setEndAnchor(to);

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
@@ -27,14 +27,14 @@ public class Connection extends Line implements ChangeListener<Number> , Initial
 	/**
 	 * Method that creates a new instance of this class along with it's visual
 	 * representation. 
-	 * @param Block to connect from.
-	 * @param Anchor to start from.
-	 * @param Block to connect to.
-	 * @param Anchor to end at.
+	 * @param from Block to connect from.
+	 * @param fromAnchor Anchor to start from.
+	 * @param to Block to connect to.
+	 * @param toAnchor Anchor to end at.
 	 * @return a new instance of this class
 	 * @throws IOException
 	 */
-	public Connection(Block from, ConnectionAnchor fromAnchor, Block to, ConnectionAnchor toAnchor) throws IOException {
+	public Connection(Block from, OutputAnchor fromAnchor, Block to, InputAnchor toAnchor) throws IOException {
 		fxmlLoader = new FXMLLoader(getClass().getResource("/ui/Connection.fxml"));
 		fxmlLoader.setRoot(this);
 		fxmlLoader.setController(this);

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
@@ -15,7 +15,7 @@ import java.util.ResourceBundle;
  * 
  * Other data types will be supported in the future
  */
-public class ConnectionAnchor extends Circle implements Initializable{
+public class ConnectionAnchor extends Circle implements Initializable {
 
     /** Indication of what dataType this Anchor supports.*/
     public StringProperty dataType;

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
@@ -14,7 +14,7 @@ import java.util.ResourceBundle;
  * 
  * Other data types will be supported in the future
  */
-public class ConnectionAnchor extends Circle implements Initializable {
+public abstract class ConnectionAnchor extends Circle implements Initializable {
     /** The fxmlLoader responsible for loading the fxml of this Block.*/
     private FXMLLoader fxmlLoader;
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
@@ -3,6 +3,7 @@ package nl.utwente.group10.ui.components;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.shape.Circle;
+import nl.utwente.group10.ui.CustomUIPane;
 
 import java.io.IOException;
 import java.net.URL;
@@ -18,7 +19,12 @@ public abstract class ConnectionAnchor extends Circle implements Initializable {
     /** The fxmlLoader responsible for loading the fxml of this Block.*/
     private FXMLLoader fxmlLoader;
 
-    public ConnectionAnchor() throws IOException {
+    /** Our parent CustomUIPane. */
+    private CustomUIPane pane;
+
+    public ConnectionAnchor(CustomUIPane pane) throws IOException {
+        this.pane = pane;
+
         fxmlLoader = new FXMLLoader(getClass().getResource("/ui/ConnectionAnchor.fxml"));
         fxmlLoader.setRoot(this);
         fxmlLoader.setController(this);			

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
@@ -1,17 +1,13 @@
 package nl.utwente.group10.ui.components;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.ResourceBundle;
-
-import nl.utwente.ewi.caes.tactilefx.fxml.TactileBuilderFactory;
-import nl.utwente.group10.ui.Main;
-import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.shape.Circle;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ResourceBundle;
 
 /**
  * Represent an Anchor point on either a Block or a Line

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
@@ -1,6 +1,5 @@
 package nl.utwente.group10.ui.components;
 
-import javafx.beans.property.StringProperty;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.shape.Circle;
@@ -16,10 +15,6 @@ import java.util.ResourceBundle;
  * Other data types will be supported in the future
  */
 public class ConnectionAnchor extends Circle implements Initializable {
-
-    /** Indication of what dataType this Anchor supports.*/
-    public StringProperty dataType;
-
     /** The fxmlLoader responsible for loading the fxml of this Block.*/
     private FXMLLoader fxmlLoader;
 
@@ -37,27 +32,5 @@ public class ConnectionAnchor extends Circle implements Initializable {
     
     public FXMLLoader getLoader(){
         return fxmlLoader;
-    }
-
-     /**
-     * @param the type of data accepted by this Anchor.
-     */
-    public void setDataType(String dataType) {
-        this.dataType.set(dataType);
-    }
-
-    /**
-     * @return the type of data accepted by this Anchor.
-     */
-    public String getDataType() {
-        return dataType.get();
-    }
-    
-    /**
-     * the StringProperty for the data type of this Anchor.
-     * @return value
-     */
-    public StringProperty dataTypeProperty() {
-        return dataType;
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ConnectionAnchor.java
@@ -22,7 +22,11 @@ public abstract class ConnectionAnchor extends Circle implements Initializable {
     /** Our parent CustomUIPane. */
     private CustomUIPane pane;
 
-    public ConnectionAnchor(CustomUIPane pane) throws IOException {
+    /** Our parent Block. */
+    private Block block;
+
+    public ConnectionAnchor(Block block, CustomUIPane pane) throws IOException {
+        this.block = block;
         this.pane = pane;
 
         fxmlLoader = new FXMLLoader(getClass().getResource("/ui/ConnectionAnchor.fxml"));
@@ -31,7 +35,15 @@ public abstract class ConnectionAnchor extends Circle implements Initializable {
 
         fxmlLoader.load();
     }
-    
+
+    public Block getBlock() {
+        return block;
+    }
+
+    public CustomUIPane getPane() {
+        return pane;
+    }
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
@@ -5,6 +5,7 @@ import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
 import nl.utwente.group10.haskell.expr.Expr;
+import nl.utwente.group10.ui.CustomUIPane;
 
 import java.io.IOException;
 
@@ -31,14 +32,14 @@ public class DisplayBlock extends Block {
      * @return new DisplayBlock instance
      * @throws IOException
      */
-    public DisplayBlock() throws IOException {
-        super("DisplayBlock", null);
+    public DisplayBlock(CustomUIPane pane) throws IOException {
+        super("DisplayBlock", pane);
 
         output = new SimpleStringProperty("New Output");
         
         this.getLoader().load();
         
-        inputAnchor = new InputAnchor();
+        inputAnchor = new InputAnchor(pane);
         anchorSpace.getChildren().add(inputAnchor);
         outputSpace.getChildren().add(this.getOutputAnchor());
         

--- a/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
@@ -21,7 +21,7 @@ public class DisplayBlock extends Block {
     /** The output this Block is displaying.**/
     private StringProperty output;
 
-    private ConnectionAnchor inputAnchor;
+    private InputAnchor inputAnchor;
     
     @FXML private Pane anchorSpace;
     
@@ -75,9 +75,10 @@ public class DisplayBlock extends Block {
 
     @Override
     public Expr asExpr() {
-        return null;
+        return inputAnchor.asExpr();
     }
 
     public void invalidate() {
+        setOutput(inputAnchor.asExpr().toHaskell());
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.layout.Pane;
 import nl.utwente.ewi.caes.tactilefx.fxml.TactileBuilderFactory;
+import nl.utwente.group10.haskell.expr.Expr;
 
 import java.io.IOException;
 
@@ -73,4 +74,11 @@ public class DisplayBlock extends Block {
         return inputAnchor;
     }
 
+    @Override
+    public Expr asExpr() {
+        return null;
+    }
+
+    public void invalidate() {
+    }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
@@ -39,7 +39,7 @@ public class DisplayBlock extends Block {
         
         this.getLoader().load();
         
-        inputAnchor = new InputAnchor(pane);
+        inputAnchor = new InputAnchor(this, pane);
         anchorSpace.getChildren().add(inputAnchor);
         outputSpace.getChildren().add(this.getOutputAnchor());
         

--- a/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
@@ -3,9 +3,7 @@ package nl.utwente.group10.ui.components;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
 import javafx.scene.layout.Pane;
-import nl.utwente.ewi.caes.tactilefx.fxml.TactileBuilderFactory;
 import nl.utwente.group10.haskell.expr.Expr;
 
 import java.io.IOException;

--- a/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
@@ -38,7 +38,7 @@ public class DisplayBlock extends Block {
         
         this.getLoader().load();
         
-        inputAnchor = new ConnectionAnchor();
+        inputAnchor = new InputAnchor();
         anchorSpace.getChildren().add(inputAnchor);
         outputSpace.getChildren().add(this.getOutputAnchor());
         

--- a/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/DisplayBlock.java
@@ -4,6 +4,8 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
+import nl.utwente.group10.ghcj.GhciException;
+import nl.utwente.group10.ghcj.GhciSession;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.ui.CustomUIPane;
 
@@ -79,6 +81,11 @@ public class DisplayBlock extends Block {
     }
 
     public void invalidate() {
-        setOutput(inputAnchor.asExpr().toHaskell());
+        try {
+            GhciSession ghci = GhciSession.getInstance();
+            setOutput(ghci.pull(inputAnchor.asExpr()));
+        } catch (GhciException e) {
+            setOutput("???");
+        }
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -33,8 +33,6 @@ public class FunctionBlock extends Block {
 	/** intstance to create Events for this FunctionBlock. **/
 	private static CustomGesture cg;
 
-	@FXML private Pane nestSpace;
-	
 	@FXML private Pane anchorSpace;
 	
 	@FXML private Pane outputSpace;
@@ -97,8 +95,7 @@ public class FunctionBlock extends Block {
 	 * @param node to nest
 	 */
 	public void nest(Node node) {
-		name.set("Higher order function");
-		nestSpace.getChildren().add(node);
+		throw new UnsupportedOperationException();
 	}
 
 	/**

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
  */
 public class FunctionBlock extends Block {
 	/** The inputs for this FunctionBlock.**/
-	private ConnectionAnchor[] inputs;
+	private InputAnchor[] inputs;
 
 	/** The name of this Function. **/
 	private StringProperty name;
@@ -67,11 +67,11 @@ public class FunctionBlock extends Block {
 			t = ft.getArgs()[1];
 		}
 
-		this.inputs = new ConnectionAnchor[args.size()];
+		this.inputs = new InputAnchor[args.size()];
 
 		// Create anchors and labels for each argument
 		for (int i = 0; i < args.size(); i++) {
-			inputs[i] = new ConnectionAnchor();
+			inputs[i] = new InputAnchor();
 			anchorSpace.getChildren().add(inputs[i]);
 
 			argumentSpace.getChildren().add(new Label(args.get(i)));

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import javafx.scene.control.Label;
+import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.ui.CustomUIPane;
@@ -170,5 +171,10 @@ public class FunctionBlock extends Block {
 			index++;
 		}
 		return index;
+	}
+
+	@Override
+	public Expr asExpr() {
+		return null;
 	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -6,7 +6,9 @@ import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
+import nl.utwente.group10.haskell.expr.Apply;
 import nl.utwente.group10.haskell.expr.Expr;
+import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.ui.CustomUIPane;
@@ -171,6 +173,10 @@ public class FunctionBlock extends Block {
 
 	@Override
 	public Expr asExpr() {
-		return null;
+		Expr expr = new Ident(getName());
+
+		for (InputAnchor in : getInputs()) expr = new Apply(expr, in.asExpr());
+
+		return expr;
 	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -69,7 +69,7 @@ public class FunctionBlock extends Block {
 
 		// Create anchors and labels for each argument
 		for (int i = 0; i < args.size(); i++) {
-			inputs[i] = new InputAnchor();
+			inputs[i] = new InputAnchor(pane);
 			anchorSpace.getChildren().add(inputs[i]);
 
 			argumentSpace.getChildren().add(new Label(args.get(i)));

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -69,7 +69,7 @@ public class FunctionBlock extends Block {
 
 		// Create anchors and labels for each argument
 		for (int i = 0; i < args.size(); i++) {
-			inputs[i] = new InputAnchor(pane);
+			inputs[i] = new InputAnchor(this, pane);
 			anchorSpace.getChildren().add(inputs[i]);
 
 			argumentSpace.getChildren().add(new Label(args.get(i)));

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -3,18 +3,17 @@ package nl.utwente.group10.ui.components;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
-
-import java.io.IOException;
-import java.util.ArrayList;
-
+import javafx.scene.Node;
 import javafx.scene.control.Label;
+import javafx.scene.layout.Pane;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.gestures.CustomGesture;
-import javafx.scene.Node;
-import javafx.scene.layout.Pane;
+
+import java.io.IOException;
+import java.util.ArrayList;
 
 /**
  * Main building block for the visual interface, this class

--- a/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/FunctionBlock.java
@@ -152,7 +152,7 @@ public class FunctionBlock extends Block {
 	 * FunctionBlock
 	 * @return inputAnchors
 	 */
-	public ConnectionAnchor[] getInputs(){
+	public InputAnchor[] getInputs(){
 		return inputs;
 	}
 	

--- a/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
@@ -1,6 +1,8 @@
 package nl.utwente.group10.ui.components;
 
 import javafx.scene.input.MouseEvent;
+import nl.utwente.group10.haskell.expr.Expr;
+import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.ui.CustomUIPane;
 
 import java.io.IOException;
@@ -33,5 +35,13 @@ public class InputAnchor extends ConnectionAnchor {
 
             pane.invalidate();
         });
+    }
+
+    public Expr asExpr() {
+        if (up.isPresent()) {
+            return up.get().getInputFunction().asExpr();
+        } else {
+            return new Ident("undefined");
+        }
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
@@ -30,6 +30,8 @@ public class InputAnchor extends ConnectionAnchor {
 
                 return null;
             });
+
+            pane.invalidate();
         });
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
@@ -1,9 +1,11 @@
 package nl.utwente.group10.ui.components;
 
+import nl.utwente.group10.ui.CustomUIPane;
+
 import java.io.IOException;
 
 public class InputAnchor extends ConnectionAnchor {
-    public InputAnchor() throws IOException {
-        super();
+    public InputAnchor(CustomUIPane pane) throws IOException {
+        super(pane);
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
@@ -1,0 +1,9 @@
+package nl.utwente.group10.ui.components;
+
+import java.io.IOException;
+
+public class InputAnchor extends ConnectionAnchor {
+    public InputAnchor() throws IOException {
+        super();
+    }
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/InputAnchor.java
@@ -1,11 +1,35 @@
 package nl.utwente.group10.ui.components;
 
+import javafx.scene.input.MouseEvent;
 import nl.utwente.group10.ui.CustomUIPane;
 
 import java.io.IOException;
+import java.util.Optional;
 
 public class InputAnchor extends ConnectionAnchor {
-    public InputAnchor(CustomUIPane pane) throws IOException {
-        super(pane);
+    private Optional<Connection> up;
+
+    public InputAnchor(Block block, CustomUIPane pane) throws IOException {
+        super(block, pane);
+
+        up = Optional.empty();
+
+        this.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+            up.map(oldAnchor -> {
+                return pane.getChildren().removeAll(oldAnchor);
+            });
+
+            pane.getLastOutputAnchor().map(anchor -> {
+                try {
+                    Connection upstream = new Connection(anchor, this);
+                    pane.getChildren().addAll(upstream);
+                    up = Optional.of(upstream);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+
+                return null;
+            });
+        });
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/OutputAnchor.java
@@ -1,9 +1,11 @@
 package nl.utwente.group10.ui.components;
 
+import nl.utwente.group10.ui.CustomUIPane;
+
 import java.io.IOException;
 
 public class OutputAnchor extends ConnectionAnchor {
-    public OutputAnchor() throws IOException {
-        super();
+    public OutputAnchor(CustomUIPane pane) throws IOException {
+        super(pane);
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/OutputAnchor.java
@@ -1,0 +1,9 @@
+package nl.utwente.group10.ui.components;
+
+import java.io.IOException;
+
+public class OutputAnchor extends ConnectionAnchor {
+    public OutputAnchor() throws IOException {
+        super();
+    }
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/components/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/OutputAnchor.java
@@ -1,11 +1,14 @@
 package nl.utwente.group10.ui.components;
 
+import javafx.scene.input.MouseEvent;
 import nl.utwente.group10.ui.CustomUIPane;
 
 import java.io.IOException;
 
 public class OutputAnchor extends ConnectionAnchor {
-    public OutputAnchor(CustomUIPane pane) throws IOException {
-        super(pane);
+    public OutputAnchor(Block block, CustomUIPane pane) throws IOException {
+        super(block, pane);
+
+        this.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> pane.setLastOutputAnchor(this));
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ValueBlock.java
@@ -3,7 +3,6 @@ package nl.utwente.group10.ui.components;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
 import javafx.scene.layout.Pane;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Value;

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ValueBlock.java
@@ -5,6 +5,9 @@ import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.layout.Pane;
+import nl.utwente.group10.haskell.expr.Expr;
+import nl.utwente.group10.haskell.expr.Value;
+import nl.utwente.group10.haskell.type.ConstT;
 
 import java.io.IOException;
 
@@ -62,5 +65,11 @@ public class ValueBlock extends Block {
      */
     public StringProperty valueProperty() {
         return value;
+    }
+
+    @Override
+    public Expr asExpr() {
+        // TODO: support more types than floats
+        return new Value(new ConstT("Float"), getValue());
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ValueBlock.java
@@ -7,6 +7,7 @@ import javafx.scene.layout.Pane;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Value;
 import nl.utwente.group10.haskell.type.ConstT;
+import nl.utwente.group10.ui.CustomUIPane;
 
 import java.io.IOException;
 
@@ -33,10 +34,10 @@ public class ValueBlock extends Block {
      * @return new ValueBlock instance
      * @throws IOException
      */
-    public ValueBlock(String val) throws IOException {
-        super("ValueBlock", null);
+    public ValueBlock(CustomUIPane pane) throws IOException {
+        super("ValueBlock", pane);
         
-        value = new SimpleStringProperty(val);
+        value = new SimpleStringProperty("5.0");
         
         this.getLoader().load();
         

--- a/Code/src/main/resources/ui/FunctionBlock.fxml
+++ b/Code/src/main/resources/ui/FunctionBlock.fxml
@@ -8,22 +8,15 @@
             <FlowPane fx:id="anchorSpace" prefWrapLength="100" vgap="50" hgap="10"/>
         </top>
         <center>
-            <BorderPane styleClass="function, block">
-                <center>
-                    <HBox>
-                        <HBox>
-                            <padding><Insets top="5" right="10" bottom="5" left="10"/></padding>
-                            <Label text="${controller.name}" styleClass="title" />
-                        </HBox>
-                        <HBox fx:id="argumentSpace" spacing="5">
-                            <padding><Insets top="5" right="5" bottom="5" left="5"/></padding>
-                        </HBox>
-                    </HBox>
-                </center>
-                <bottom>
-                    <FlowPane fx:id="nestSpace" styleClass="nestSpace" prefWrapLength="100" vgap="5"/>
-                </bottom>
-            </BorderPane>
+            <HBox styleClass="function, block">
+                <HBox>
+                    <padding><Insets top="5" right="10" bottom="5" left="10"/></padding>
+                    <Label text="${controller.name}" styleClass="title" />
+                </HBox>
+                <HBox fx:id="argumentSpace" spacing="5">
+                    <padding><Insets top="5" right="5" bottom="5" left="5"/></padding>
+                </HBox>
+            </HBox>
         </center>
         <bottom>
             <VBox fx:id="outputSpace" alignment = "center"/>

--- a/Code/src/test/java/nl/utwente/group10/ghcj/GhciEvaluatorTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ghcj/GhciEvaluatorTest.java
@@ -19,11 +19,6 @@ public class GhciEvaluatorTest {
         this.NL = System.getProperty("line.separator");
     }
 
-    @After
-    public void stopGhci() throws Exception {
-        this.ghci.close();
-    }
-
     @Test
     public void putStrLnTest() throws GhciException {
         Assert.assertEquals("Hello" + this.NL, this.ghci.eval("putStrLn \"Hello\""));

--- a/Code/src/test/java/nl/utwente/group10/ghcj/GhciSessionTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ghcj/GhciSessionTest.java
@@ -31,7 +31,7 @@ public class GhciSessionTest {
 
     @Before
     public void startSession() throws GhciException {
-        this.ghci = new GhciSession();
+        this.ghci = GhciSession.getInstance();
     }
 
     @After

--- a/Code/src/test/java/nl/utwente/group10/ghcj/GhciSessionTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ghcj/GhciSessionTest.java
@@ -21,22 +21,13 @@ public class GhciSessionTest {
     private Expr pi;
 
     @Before
-    public void setUp() throws HaskellException {
+    public void setUp() throws GhciException {
         this.env = new Env();
         this.genSet = new GenSet();
+        this.ghci = GhciSession.getInstance();
 
         this.env.put("my_pi", new ConstT("Float"));
         this.pi = new Value(new ConstT("Float"), "3.14");
-    }
-
-    @Before
-    public void startSession() throws GhciException {
-        this.ghci = GhciSession.getInstance();
-    }
-
-    @After
-    public void stopSession() throws Exception {
-        this.ghci.close();
     }
 
     @Test

--- a/Code/src/test/java/nl/utwente/group10/ui/components/DisplayBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/DisplayBlockTest.java
@@ -9,12 +9,12 @@ import org.junit.Test;
 public class DisplayBlockTest extends ComponentTest {
     @Test
     public void initTest() throws IOException {
-        assertNotNull(new DisplayBlock());
+        assertNotNull(new DisplayBlock(null));
     }
 
     @Test
     public void inputOutputTest() throws IOException {
-        DisplayBlock block = new DisplayBlock();
+        DisplayBlock block = new DisplayBlock(null);
         assertEquals(block.getOutput(), "New Output");
 
         block.setOutput("8");

--- a/Code/src/test/java/nl/utwente/group10/ui/components/ValueBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/ValueBlockTest.java
@@ -10,12 +10,13 @@ import static org.junit.Assert.assertNotNull;
 public class ValueBlockTest extends ComponentTest {
     @Test
     public void initTest() throws IOException {
-        assertNotNull(new ValueBlock("6"));
+        assertNotNull(new ValueBlock(null));
     }
 
     @Test
     public void outputTest() throws IOException {
-        ValueBlock block = new ValueBlock("6");
+        ValueBlock block = new ValueBlock(null);
+        block.setValue("6");
         assertEquals(block.getValue(), "6");
     }
 }


### PR DESCRIPTION
This PR adds enough functionality to do basic calculator-like computation. It includes the InputAnchor/OutputAnchor split, a rudimentary integration with the backend that doesn't do type checking, and a way to add (but not delete) functions and lines.