### PR TITLE
Show selected state of function blocks

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -1,7 +1,10 @@
 package nl.utwente.group10.ui;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
 import nl.utwente.ewi.caes.tactilefx.control.TactilePane;
+import nl.utwente.group10.ui.components.Block;
 import nl.utwente.group10.ui.components.DisplayBlock;
 import nl.utwente.group10.ui.components.OutputAnchor;
 import nl.utwente.group10.ui.gestures.UIEvent;
@@ -11,9 +14,11 @@ import java.util.Optional;
 
 public class CustomUIPane extends TactilePane implements GestureCallBack {
 	private Optional<OutputAnchor> anchor;
+	private ObjectProperty<Optional<Block>> selectedBlock;
 
 	public CustomUIPane() {
 		this.anchor = Optional.empty();
+		this.selectedBlock = new SimpleObjectProperty<>(Optional.empty());
 	}
 
 	public void setLastOutputAnchor(OutputAnchor anchor) {
@@ -35,5 +40,17 @@ public class CustomUIPane extends TactilePane implements GestureCallBack {
 				((DisplayBlock)node).invalidate();
 			}
 		}
+	}
+
+	public Optional<Block> getSelectedBlock() {
+		return selectedBlock.get();
+	}
+
+	public void setSelectedBlock(Block selectedBlock) {
+		this.selectedBlock.set(Optional.ofNullable(selectedBlock));
+	}
+
+	public ObjectProperty<Optional<Block>> selectedBlockProperty() {
+		return selectedBlock;
 	}
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Block.java
@@ -4,7 +4,6 @@ package nl.utwente.group10.ui.components;
 import javafx.event.EventType;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
-import javafx.scene.Node;
 import javafx.scene.layout.StackPane;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.ui.CustomUIPane;
@@ -21,14 +20,10 @@ import java.util.ResourceBundle;
  */
 
 public abstract class Block extends StackPane implements Initializable, GestureCallBack {
-	
-	/** Selected state of this Block*/
-	private boolean isSelected = false;
-	
-	/** The output of this Block.**/
+	/** The output of this Block. **/
 	private OutputAnchor output;
 	
-	/** The fxmlLoader responsible for loading the fxml of this Block.*/
+	/** The fxmlLoader responsible for loading the fxml of this Block. */
 	private FXMLLoader fxmlLoader;
 	
 	private CustomUIPane cup;
@@ -40,6 +35,14 @@ public abstract class Block extends StackPane implements Initializable, GestureC
 		
 		output = new OutputAnchor(this, pane);
 		cup = pane;
+
+		cup.selectedBlockProperty().addListener(event -> {
+			if (cup.getSelectedBlock().isPresent() && this.equals(cup.getSelectedBlock().get())) {
+				this.getStyleClass().add("selected");
+			} else {
+				this.getStyleClass().removeAll("selected");
+			}
+		});
 	}
 	
 	/**
@@ -56,34 +59,17 @@ public abstract class Block extends StackPane implements Initializable, GestureC
 	public OutputAnchor getOutputAnchor() {
 		return output;
 	}
-	
-	/**
-	 * Set the selected boolean state of this Block
-	 * @param selectedState
-	 */
-	public void setSelected(boolean selectedState) {
-		//TODO If another object is selected then deselect it first!!
-		isSelected = selectedState;
-	}
-	
+
 	@Override
 	public void initialize(URL location, ResourceBundle resources) {
 	}
 	
 	@Override
 	public void handleCustomEvent(UIEvent event) {
-		EventType eventType = event
-				.getEventType();
+		EventType eventType = event.getEventType();
+
 		if (eventType.equals(UIEvent.TAP)) {
-			for(Node n : cup.getChildren()){
-				if(n instanceof Block){
-					if(((Block) n).isSelected){
-						((Block) n).setSelected(false);
-					}
-				}
-			}
-			this.setSelected(true);
-			System.out.println("Block is selected");
+			cup.setSelectedBlock(this);
 		} else if (eventType.equals(UIEvent.TAP_HOLD)) {
 			//TODO: open the quick-menu
 		}

--- a/Code/src/main/resources/ui/style.css
+++ b/Code/src/main/resources/ui/style.css
@@ -6,6 +6,10 @@
 	-fx-border-width: 2;
 }
 
+.selected .block {
+	-fx-background-color: skyblue;
+}
+
 .function.block .title {
 	-fx-text-fill: #333333;
 	-fx-font-size: 14px;

--- a/Code/src/test/java/nl/utwente/group10/ui/components/DisplayBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/DisplayBlockTest.java
@@ -4,17 +4,18 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 
+import nl.utwente.group10.ui.CustomUIPane;
 import org.junit.Test;
 
 public class DisplayBlockTest extends ComponentTest {
     @Test
     public void initTest() throws IOException {
-        assertNotNull(new DisplayBlock(null));
+        assertNotNull(new DisplayBlock(new CustomUIPane()));
     }
 
     @Test
     public void inputOutputTest() throws IOException {
-        DisplayBlock block = new DisplayBlock(null);
+        DisplayBlock block = new DisplayBlock(new CustomUIPane());
         assertEquals(block.getOutput(), "New Output");
 
         block.setOutput("8");

--- a/Code/src/test/java/nl/utwente/group10/ui/components/ValueBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/ValueBlockTest.java
@@ -1,5 +1,6 @@
 package nl.utwente.group10.ui.components;
 
+import nl.utwente.group10.ui.CustomUIPane;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -10,12 +11,12 @@ import static org.junit.Assert.assertNotNull;
 public class ValueBlockTest extends ComponentTest {
     @Test
     public void initTest() throws IOException {
-        assertNotNull(new ValueBlock(null));
+        assertNotNull(new ValueBlock(new CustomUIPane()));
     }
 
     @Test
     public void outputTest() throws IOException {
-        ValueBlock block = new ValueBlock(null);
+        ValueBlock block = new ValueBlock(new CustomUIPane());
         block.setValue("6");
         assertEquals(block.getValue(), "6");
     }


### PR DESCRIPTION
This commit reworks the selection state of function blocks so that only
one block can be selected at any time. It also contains a style so that
selected function blocks show sky blue instead of alice blue.