### PR TITLE
UI Visual feedback for missing arguments and type mismatches

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -37,6 +37,14 @@ public class CustomUIPane extends TactilePane {
             }
         }
     }
+    
+    public final void errorAll() {
+        for (Node node : getChildren()) {
+            if (node instanceof Block) {
+                ((Block)node).error();
+            }
+        }
+    }
 
     public Optional<Block> getSelectedBlock() {
         return selectedBlock.get();

--- a/Code/src/main/java/nl/utwente/group10/ui/MainMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/MainMenu.java
@@ -35,13 +35,17 @@ public class MainMenu extends ContextMenu {
         valueBlockItem.setOnAction(event -> addValueBlock());
         MenuItem displayBlockItem = new MenuItem("Display Block");
         displayBlockItem.setOnAction(event -> addDisplayBlock());
+        
+        //TODO remove this item when debugging of visualFeedback is done
+        MenuItem errorItem = new MenuItem("Error all Blocks");
+        errorItem.setOnAction(event -> parent.errorAll());
 
         MenuItem quitItem = new MenuItem("Quit");
         quitItem.setOnAction(event -> System.exit(0));
 
         SeparatorMenuItem sep = new SeparatorMenuItem();
 
-        this.getItems().addAll(valueBlockItem, displayBlockItem, sep, quitItem);
+        this.getItems().addAll(valueBlockItem, displayBlockItem, sep, errorItem, quitItem);
     }
 
     private void addFunctionBlock(Entry entry) {

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
@@ -2,6 +2,10 @@ package nl.utwente.group10.ui.components;
 
 import java.util.Optional;
 
+import nl.utwente.group10.haskell.env.Env;
+import nl.utwente.group10.haskell.exceptions.HaskellException;
+import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
+import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.ui.components.blocks.Block;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -94,10 +98,12 @@ public class Connection extends ConnectionLine implements
         }
         startAnchor = Optional.of(start);
         startAnchor.get().setConnection(this);
-        checkError();
         
         startAnchor.get().getBlock().layoutXProperty().addListener(this);
         startAnchor.get().getBlock().layoutYProperty().addListener(this);
+        
+        checkError();
+        
         updateStartPosition();
     }
 
@@ -214,14 +220,16 @@ public class Connection extends ConnectionLine implements
      * If the connection results in an invalid operation a visual
      * error will be displayed.
      */
-    public void checkError() {
-        if(startAnchor!=null && endAnchor!=null) {
-            //Can this method be used to evaluate validity of the operation?
-            //endAnchor.get().getBlock().asExpr().analyze(env, genSet);
-            if (true) {
-                this.setStyle("-fx-stroke: black;");
-            } else {
-                this.setStyle("-fx-stroke: red;");
+    private void checkError() {
+        if(startAnchor.isPresent() && endAnchor.isPresent()) {
+            try {
+                //TODO Obviously this will cause errors, we need a way to access the Env
+                endAnchor.get().getBlock().asExpr().analyze(new Env(), new GenSet());
+                this.getStyleClass().remove("error");
+            } catch (HaskellTypeError e) {
+                this.getStyleClass().add("error");
+            } catch (HaskellException e) {
+                e.printStackTrace();
             }
         }
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
@@ -98,12 +98,12 @@ public class Connection extends ConnectionLine implements
         }
         startAnchor = Optional.of(start);
         startAnchor.get().setConnection(this);
-        
+
         startAnchor.get().getBlock().layoutXProperty().addListener(this);
         startAnchor.get().getBlock().layoutYProperty().addListener(this);
-        
+
         checkError();
-        
+
         updateStartPosition();
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/Connection.java
@@ -94,7 +94,8 @@ public class Connection extends ConnectionLine implements
         }
         startAnchor = Optional.of(start);
         startAnchor.get().setConnection(this);
-
+        checkError();
+        
         startAnchor.get().getBlock().layoutXProperty().addListener(this);
         startAnchor.get().getBlock().layoutYProperty().addListener(this);
         updateStartPosition();
@@ -113,6 +114,7 @@ public class Connection extends ConnectionLine implements
         }
         endAnchor = Optional.of(end);
         endAnchor.get().setConnection(this);
+        checkError();
 
         endAnchor.get().getBlock().layoutXProperty().addListener(this);
         endAnchor.get().getBlock().layoutYProperty().addListener(this);
@@ -205,5 +207,22 @@ public class Connection extends ConnectionLine implements
     public String toString() {
         return "Connection connecting \n(out) " + startAnchor + "   to\n(in)  "
                 + endAnchor;
+    }
+    
+    /**
+     * This method evaluates the validity of the created connection.
+     * If the connection results in an invalid operation a visual
+     * error will be displayed.
+     */
+    public void checkError() {
+        if(startAnchor!=null && endAnchor!=null) {
+            //Can this method be used to evaluate validity of the operation?
+            //endAnchor.get().getBlock().asExpr().analyze(env, genSet);
+            if (true) {
+                this.setStyle("-fx-stroke: black;");
+            } else {
+                this.setStyle("-fx-stroke: red;");
+            }
+        }
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -70,4 +70,12 @@ public abstract class Block extends StackPane {
      * @return an expression that evaluates to what this block is.
      */
     public abstract Expr asExpr();
+
+    /** @return the parent of this Block. */
+    public CustomUIPane getPane() {
+        return parentPane;
+    }
+    
+    /** DEBUG METHOD trigger the error state for this Block */
+    public abstract void error();
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -94,4 +94,9 @@ public class DisplayBlock extends Block {
             setOutput("???");
         }
     }
+    
+    @Override
+    public void error() {
+        this.getStyleClass().add("error");
+    }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -158,9 +158,20 @@ public class FunctionBlock extends Block {
     @Override
     public final Expr asExpr() {
         Expr expr = new Ident(getName());
-
         for (InputAnchor in : getInputs()) expr = new Apply(expr, in.asExpr());
-
+        
         return expr;
+    }
+
+    @Override
+    public final void error() {
+            for (InputAnchor in : getInputs()) {
+                if (!in.isConnected()) {
+                    argumentSpace.getChildren().get(getArgumentIndex(in)).getStyleClass().add("error");
+                } else if (in.isConnected()){
+                    argumentSpace.getChildren().get(getArgumentIndex(in)).getStyleClass().remove("error");
+                }
+            }
+            this.getStyleClass().add("error");
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
@@ -66,4 +66,9 @@ public class ValueBlock extends Block {
         // TODO: support more types than floats
         return new Value(new ConstT("Float"), getValue());
     }
+
+    @Override
+    public void error() {
+        this.getStyleClass().add("error");
+    }
 }

--- a/Code/src/main/resources/ui/style.css
+++ b/Code/src/main/resources/ui/style.css
@@ -1,50 +1,58 @@
 .block {
-	-fx-font-size: 20px;
-	-fx-font-weight: bold;
-	-fx-background-color: aliceblue;
-	-fx-border-color: black;
-	-fx-border-width: 2;
+    -fx-font-size: 20px;
+    -fx-font-weight: bold;
+    -fx-background-color: aliceblue;
+    -fx-border-color: black;
+    -fx-border-width: 2;
 }
 
+.error .block {
+    -fx-border-color: red;
+}
 .selected .block {
-	-fx-background-color: skyblue;
+    -fx-background-color: skyblue;
 }
 
 .function.block .title {
-	-fx-text-fill: #333333;
-	-fx-font-size: 14px;
-	-fx-font-weight: bold;
+    -fx-text-fill: #333333;
+    -fx-font-size: 14px;
+    -fx-font-weight: bold;
 }
 
 .function.block .description {
-	-fx-font-size: 12px;
-	-fx-padding: 0;
+    -fx-font-size: 12px;
+    -fx-padding: 0;
 }
 
 .function.block .nestSpace {
-	-fx-padding: 15;
+    -fx-padding: 15;
 }
 
 .function.block #argumentSpace Label {
-	-fx-padding: 0 5 0 5;
-	-fx-font-size: 14px;
-	-fx-font-weight: none;
-	-fx-background-color:white;
-	-fx-border-color: black;
-	-fx-border-width: 1;
+    -fx-padding: 0 5 0 5;
+    -fx-font-size: 14px;
+    -fx-font-weight: none;
+    -fx-background-color:white;
+    -fx-border-color: black;
+    -fx-border-width: 1;
+}
+
+.function.block #argumentSpace Label.error {
+    -fx-background-color:pink;
+    -fx-border-color: red;
 }
 
 .function.block #argumentSpace Label.result {
-	-fx-background-color: black;
-	-fx-text-fill: white;
+    -fx-background-color: black;
+    -fx-text-fill: white;
 }
 
 .value.block {
-	-fx-background-color: #8e44ad;
+    -fx-background-color: #8e44ad;
 }
 
 .display.block {
-	-fx-background-color: #c0392b;
+    -fx-background-color: #c0392b;
 }
 
 .value.block .title, .display.block .title {
@@ -52,11 +60,11 @@
 }
 
 .block .title {
-	-fx-text-fill: #ecf0f1;
+    -fx-text-fill: #ecf0f1;
 }
 
 .connection {
-	-fx-stroke-width: 3px;
-	-fx-stroke: red;
-	-fx-fill: null;
+    -fx-stroke-width: 3px;
+    -fx-stroke: red;
+    -fx-fill: null;
 }


### PR DESCRIPTION
 * Connections now turn red when there is a type mismatch between both ends.

 * Argument fields in FunctionBlock now have red outlining whenever their InputAnchors have no input.

 * **Highlighted issue**: there seems to be no discernible way to access the Env or GenSet values for the application, this makes evaluation requests by components seemingly impossible. See TODO in Connection.java