### PR TITLE
Fixes for type classes

### DIFF
--- a/Code/src/main/antlr4/nl/utwente/group10/haskell/typeparser/Type.g4
+++ b/Code/src/main/antlr4/nl/utwente/group10/haskell/typeparser/Type.g4
@@ -1,10 +1,10 @@
 grammar Type;
 
-CT : [A-Z][a-z]+ ;
+CT : [A-Z][A-Za-z]+ ;
 VT : [a-z]+ ;
 WS : [ \t\r\n]+ -> skip ;
 
-type : typeClasses ? innerType ;
+type : (typeClasses '=>')? innerType ;
 innerType : functionType | compoundType ; // function type
 functionType : compoundType '->' innerType ;
 compoundType : constantType | variableType | tupleType | listType | parenType ;
@@ -13,11 +13,11 @@ tupleType : '(' innerType (',' innerType)+ ')' ; // tuple type, k>=2
 listType : '[' innerType ']' ;              // list type
 parenType : '(' innerType ')' ;             // type with parentheses
 
-constantType : typeConstructor (WS* innerType)* ;
+constantType : typeConstructor (innerType)* ;
 typeConstructor : CT ;
 variableType : VT ;
 
-typeClasses : '(' typeWithClass (',' typeWithClass)* ')' '=>' | typeWithClass '=>' ;
-typeWithClass : typeClass WS* classedType ;
+typeClasses : '(' typeWithClass (',' typeWithClass)* ')' | typeWithClass ;
+typeWithClass : typeClass classedType ;
 classedType : VT ;
 typeClass : CT ;

--- a/Code/src/main/java/nl/utwente/group10/haskell/typeparser/TypeBuilderListener.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/typeparser/TypeBuilderListener.java
@@ -47,6 +47,11 @@ class TypeBuilderListener extends TypeBaseListener {
     }
 
     @Override
+    public void enterTypeWithClass(TypeParser.TypeWithClassContext ctx) {
+        this.typeClass = Optional.empty();
+    }
+
+    @Override
     public void exitClassedType(TypeParser.ClassedTypeContext ctx) {
         if (this.typeClass.isPresent()) {
             this.constraints.put(ctx.getText(), this.typeClass.get());

--- a/Code/src/test/java/nl/utwente/group10/haskell/typeparser/TypeBuilderTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/typeparser/TypeBuilderTest.java
@@ -34,9 +34,12 @@ public class TypeBuilderTest {
     @Test public void testTypeClass()   {
         Map<String, TypeClass> typeClasses = new HashMap<>();
         typeClasses.put("Num", new TypeClass("Num", new ConstT("Int"), new ConstT("Float"), new ConstT("Double")));
+        typeClasses.put("Eq", new TypeClass("Eq", new ConstT("Int"), new ConstT("Float"), new ConstT("Double"), new ConstT("Char"), new ConstT("Bool")));
         TypeBuilder builder = new TypeBuilder(typeClasses);
 
         Assert.assertEquals("(Num a)", builder.build("Num a => a").toHaskellType());
         Assert.assertEquals("((Num a) -> (Num a))", builder.build("(Num a) => (a -> a)").toHaskellType());
+        Assert.assertEquals("((Num a) -> b)", builder.build("(Num a, Nonexistent b) => a -> b").toHaskellType());
+        Assert.assertEquals("((Num a) -> (Eq b))", builder.build("(Num a, Eq b) => a -> b").toHaskellType());
     }
 }


### PR DESCRIPTION
Fixes the issues where...

- ... a typeclass contains an uppercase character after the first position (e.g. ```RealFrac```). This was an issue with the lexer.
- ... an unknown typeclass is ignored by the parser where it unintentionally falled back to the last used type class.