### PR TITLE
TypeMismatch indications for Connections

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -42,6 +42,9 @@ public class CustomUIPane extends TactilePane {
         for (Node node : getChildren()) {
             if (node instanceof Block) {
                 ((Block)node).error();
+            } else if (node instanceof Connection) {
+                System.out.println("derp");
+                ((Connection)node).error();
             }
         }
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
@@ -237,4 +237,9 @@ public class Connection extends ConnectionLine implements
             }
         }
     }
+    
+    /** DEBUG METHOD trigger the error state for this Connection */
+    public void error() {
+        this.getStyleClass().add("error");
+    }
 }

--- a/Code/src/main/resources/ui/style.css
+++ b/Code/src/main/resources/ui/style.css
@@ -69,6 +69,10 @@ CustomUIPane {
 
 .connection {
     -fx-stroke-width: 3px;
-    -fx-stroke: red;
+    -fx-stroke: white;
     -fx-fill: null;
+}
+
+.connection.error {
+    -fx-stroke: orange;
 }


### PR DESCRIPTION
Right now connection lines will turn Orange for their error state, since there is no clear implementation yet to provide TypeMismatch errors the visualisation for specific errors has not yet been implemented.