### PR TITLE
Parse Catalog from stream instead of from path

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/haskell/catalog/Catalog.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/catalog/Catalog.java
@@ -36,7 +36,7 @@ public abstract class Catalog {
 
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 
-            return dBuilder.parse(xmlFile.getPath());
+            return dBuilder.parse(xmlFile.openStream());
         } catch (IOException | ParserConfigurationException | SAXException e) {
             throw new CatalogException(e);
         }


### PR DESCRIPTION
When running from a JAR file, resources can't be opened directly:
they're not files on their own and therefore do not really have a path.
They can, however, be opened; the InputStream can then be passed to
`parse`.

This should fix the JAR file generated by `mvn package`.