### PR TITLE
Fix draw order of connections

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
@@ -43,7 +43,7 @@ public class ConnectionCreationManager {
 		} else if (anchor instanceof InputAnchor) {
 			newConnection = new Connection((InputAnchor) anchor);
 		}
-		pane.getChildren().add(newConnection);
+		pane.getChildren().add(0, newConnection);
 		connections.put(id, newConnection);
 		return newConnection;
 	}


### PR DESCRIPTION
This always draws new connections behind blocks, instead of drawing them in
front at first, then sinking to the back as blocks get selected and brought to
the front by TactilePane.