### PR TITLE
Make GhciSession NOT a Singleton

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ghcj/GhciSession.java
+++ b/Code/src/main/java/nl/utwente/group10/ghcj/GhciSession.java
@@ -2,7 +2,6 @@ package nl.utwente.group10.ghcj;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Optional;
 
 import nl.utwente.group10.haskell.exceptions.HaskellException;
 import nl.utwente.group10.haskell.exceptions.HaskellSyntaxError;
@@ -16,16 +15,13 @@ public final class GhciSession implements Closeable {
     /** The evaluator this GhciSession will communicate with. */
     private final GhciEvaluator ghci;
 
-    /** Singleton instance. */
-    private static Optional<GhciSession> instance = Optional.empty();
-
     /**
      * Builds a new communication session with ghci.
      *
      * @throws GhciException when ghci can not be found, can not be executed,
      *         or does not understand our setup sequence.
      */
-    private GhciSession() throws GhciException {
+    public GhciSession() throws GhciException {
         this.ghci = new GhciEvaluator();
     }
 
@@ -68,18 +64,5 @@ public final class GhciSession implements Closeable {
     @Override
     public void close() throws IOException {
         this.ghci.close();
-    }
-
-    /**
-     * @return An instance of GhciSession to work with.
-     * @throws GhciException when there is a problem setting up the connection with ghci, this usually means that ghci
-     *                       is not installed on your system.
-     */
-    public static GhciSession getInstance() throws GhciException {
-        if (!instance.isPresent()) {
-            instance = Optional.of(new GhciSession());
-        }
-
-        return instance.get();
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -7,6 +7,8 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
 import nl.utwente.ewi.caes.tactilefx.control.TactilePane;
+import nl.utwente.group10.ghcj.GhciException;
+import nl.utwente.group10.ghcj.GhciSession;
 import nl.utwente.group10.ui.components.blocks.Block;
 import nl.utwente.group10.ui.components.blocks.DisplayBlock;
 import nl.utwente.group10.ui.components.lines.Connection;
@@ -18,6 +20,7 @@ import nl.utwente.group10.ui.handlers.ConnectionCreationManager;
 public class CustomUIPane extends TactilePane {
     private ObjectProperty<Optional<Block>> selectedBlock;
     private ConnectionCreationManager connectionCreationManager;
+    private Optional<GhciSession> ghci;
 
     /**
      * Constructs a new instance.
@@ -25,6 +28,12 @@ public class CustomUIPane extends TactilePane {
     public CustomUIPane() {
         this.connectionCreationManager = new ConnectionCreationManager(this);
         this.selectedBlock = new SimpleObjectProperty<>(Optional.empty());
+
+        try {
+            this.ghci = Optional.of(new GhciSession());
+        } catch (GhciException e) {
+            this.ghci = Optional.empty();
+        }
     }
 
     /**
@@ -91,5 +100,9 @@ public class CustomUIPane extends TactilePane {
 
     public ConnectionCreationManager getConnectionCreationManager() {
         return connectionCreationManager;
+    }
+
+    public Optional<GhciSession> getGhciSession() {
+        return ghci;
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -1,6 +1,7 @@
 package nl.utwente.group10.ui.components.blocks;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -88,8 +89,11 @@ public class DisplayBlock extends Block {
      */
     public final void invalidate() {
         try {
-            GhciSession ghci = GhciSession.getInstance();
-            setOutput(ghci.pull(inputAnchor.asExpr()));
+            Optional<GhciSession> ghci = getPane().getGhciSession();
+
+            if (ghci.isPresent()) {
+                setOutput(ghci.get().pull(inputAnchor.asExpr()));
+            }
         } catch (GhciException e) {
             setOutput("???");
         }

--- a/Code/src/test/java/nl/utwente/group10/ghcj/GhciSessionTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ghcj/GhciSessionTest.java
@@ -23,7 +23,7 @@ public class GhciSessionTest {
     public void setUp() throws GhciException {
         this.env = new Env();
         this.genSet = new GenSet();
-        this.ghci = GhciSession.getInstance();
+        this.ghci = new GhciSession();
 
         this.env.getExprTypes().put("my_pi", new ConstT("Float"));
         this.pi = new Value(new ConstT("Float"), "3.14");

--- a/Code/src/test/java/nl/utwente/group10/ui/components/blocks/DisplayBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/blocks/DisplayBlockTest.java
@@ -3,20 +3,18 @@ package nl.utwente.group10.ui.components.blocks;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.IOException;
-
 import nl.utwente.group10.ui.CustomUIPane;
 
 import org.junit.Test;
 
 public class DisplayBlockTest extends ComponentTest {
     @Test
-    public void initTest() throws IOException {
+    public void initTest() throws Exception {
         assertNotNull(new DisplayBlock(new CustomUIPane()));
     }
 
     @Test
-    public void inputOutputTest() throws IOException {
+    public void inputOutputTest() throws Exception {
         DisplayBlock block = new DisplayBlock(new CustomUIPane());
         assertEquals(block.getOutput(), "New Output");
 

--- a/Code/src/test/java/nl/utwente/group10/ui/components/blocks/FunctionBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/blocks/FunctionBlockTest.java
@@ -3,8 +3,6 @@ package nl.utwente.group10.ui.components.blocks;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.IOException;
-
 import nl.utwente.group10.haskell.type.ConstT;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.ui.CustomUIPane;
@@ -19,10 +17,9 @@ public class FunctionBlockTest extends ComponentTest {
     /**
      * Before each test reset all the FunctionBlock instances
      * to have a clear batch to test against.
-     * @throws IOException
      */
     @Before
-    public void setUp() throws IOException{
+    public void setUp() throws Exception {
         FuncT func = new FuncT(new ConstT("Int"), new FuncT(new ConstT("Int"), new ConstT("Int")));
 
         functionBlock = new FunctionBlock("", func, new CustomUIPane());

--- a/Code/src/test/java/nl/utwente/group10/ui/components/blocks/ValueBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/blocks/ValueBlockTest.java
@@ -3,20 +3,18 @@ package nl.utwente.group10.ui.components.blocks;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.IOException;
-
 import nl.utwente.group10.ui.CustomUIPane;
 
 import org.junit.Test;
 
 public class ValueBlockTest extends ComponentTest {
     @Test
-    public void initTest() throws IOException {
+    public void initTest() throws Exception {
         assertNotNull(new ValueBlock(new CustomUIPane()));
     }
 
     @Test
-    public void outputTest() throws IOException {
+    public void outputTest() throws Exception {
         ValueBlock block = new ValueBlock(new CustomUIPane());
         block.setValue("6");
         assertEquals(block.getValue(), "6");


### PR DESCRIPTION
There were reasons for making GhciSession a singleton, but none of them
were very good. This commit reverts that and has CustomUIPane carry
along an optional GhciSession.