### PR TITLE
Have ComponentLoader swallow/rethrow IOExceptions

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/components/ComponentLoader.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ComponentLoader.java
@@ -2,17 +2,22 @@ package nl.utwente.group10.ui.components;
 
 import javafx.fxml.FXMLLoader;
 
+import java.io.IOException;
+
 /**
  * This interface is responsible for providing a Class specific FXMLLoader
  * to each UI Component.
  */
 public interface ComponentLoader {
+    default void loadFXML(String name) {
+        try {
+            FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource(String.format("/ui/%s.fxml", name)));
+            fxmlLoader.setRoot(this);
+            fxmlLoader.setController(this);
 
-    default FXMLLoader getFXMLLoader(String name) {
-        FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource(String.format("/ui/%s.fxml", name)));
-        fxmlLoader.setRoot(this);
-        fxmlLoader.setController(this);
-        
-        return fxmlLoader;
+            fxmlLoader.load();
+        } catch (IOException e) {
+            throw new RuntimeException("A required FXML file, " + name + ", could not be loaded.", e);
+        }
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/ComponentLoader.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/ComponentLoader.java
@@ -3,15 +3,22 @@ package nl.utwente.group10.ui.components;
 import javafx.fxml.FXMLLoader;
 
 import java.io.IOException;
+import java.net.URL;
 
 /**
- * This interface is responsible for providing a Class specific FXMLLoader
- * to each UI Component.
+ * Provides a default method for loading FXML interface description files.
+ *
+ * The ComponentLoader is implemented as an interface so it can be added to
+ * other classes without forcing those classes to inherit from it.
+ *
+ * loadFXML will throw a RuntimeException when loading the FXML file fails,
+ * which should never happen as it will only load from resources.
  */
 public interface ComponentLoader {
     default void loadFXML(String name) {
         try {
-            FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource(String.format("/ui/%s.fxml", name)));
+            URL url = getClass().getResource(String.format("/ui/%s.fxml", name));
+            FXMLLoader fxmlLoader = new FXMLLoader(url);
             fxmlLoader.setRoot(this);
             fxmlLoader.setController(this);
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/CustomAlert.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/CustomAlert.java
@@ -6,16 +6,15 @@ import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
 import nl.utwente.group10.ui.CustomUIPane;
 
-import java.io.IOException;
-
 public class CustomAlert extends Pane implements ComponentLoader {
     @FXML
     private Text text;
 
     private CustomUIPane pane;
 
-    public CustomAlert(CustomUIPane pane, String message) throws IOException {
-        this.getFXMLLoader("Alert").load();
+    public CustomAlert(CustomUIPane pane, String message) {
+        this.loadFXML("Alert");
+
         this.pane = pane;
         text.setText(message);
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
@@ -1,6 +1,5 @@
 package nl.utwente.group10.ui.components.anchors;
 
-import java.io.IOException;
 import java.util.Optional;
 
 import javafx.geometry.Point2D;
@@ -29,18 +28,12 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
     /**
      * @param block The block where this Anchor is connected to.
      * @param pane The pane this Anchor belongs to.
-     * @throws IOException when the FXML definitions cannot be loaded.
      */
     public ConnectionAnchor(Block block, CustomUIPane pane) {
         this.block = block;
         this.pane = pane;
 
-        try {
-            getFXMLLoader("ConnectionAnchor").load();
-        } catch (IOException e) {
-            // TODO Find a good way to handle this
-            e.printStackTrace();
-        }
+        loadFXML("ConnectionAnchor");
         setConnection(null);
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
@@ -33,7 +33,7 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
         this.block = block;
         this.pane = pane;
 
-        loadFXML("ConnectionAnchor");
+        this.loadFXML("ConnectionAnchor");
         setConnection(null);
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
@@ -1,6 +1,5 @@
 package nl.utwente.group10.ui.components.anchors;
 
-import java.io.IOException;
 import java.util.Optional;
 
 import nl.utwente.group10.haskell.expr.Expr;
@@ -17,9 +16,8 @@ public class InputAnchor extends ConnectionAnchor {
     /**
      * @param block The Block this anchor is connected to.
      * @param pane The parent pane this Anchor resides on.
-     * @throws IOException when the FXML definitions cannot be loaded.
      */
-    public InputAnchor(Block block, CustomUIPane pane) throws IOException {
+    public InputAnchor(Block block, CustomUIPane pane) {
         super(block, pane);
         new AnchorHandler(pane.getConnectionCreationManager(), this);
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
@@ -1,6 +1,5 @@
 package nl.utwente.group10.ui.components.anchors;
 
-import java.io.IOException;
 import java.util.Optional;
 
 import nl.utwente.group10.ui.CustomUIPane;
@@ -15,9 +14,8 @@ public class OutputAnchor extends ConnectionAnchor {
     /**
      * @param block The block this Anchor is connected to.
      * @param pane The parent pane on which this anchor resides.
-     * @throws IOException when the FXML definition of this anchor cannot be loaded.
      */
-    public OutputAnchor(Block block, CustomUIPane pane) throws IOException {
+    public OutputAnchor(Block block, CustomUIPane pane) {
         super(block, pane);
         new AnchorHandler(pane.getConnectionCreationManager(),this);
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -1,7 +1,5 @@
 package nl.utwente.group10.ui.components.blocks;
 
-import java.io.IOException;
-
 import javafx.application.Platform;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
@@ -37,20 +35,13 @@ public abstract class Block extends StackPane implements ComponentLoader {
     private CircleMenu circleMenu;
 
     /**
-     * @param blockName
-     *            Name of this block. The name is used to load the FXML
-     *            definition for this block.
      * @param pane
      *            The pane this block belongs to.
      */
     public Block(CustomUIPane pane) {
         parentPane = pane;
 
-        try {
-            output = new OutputAnchor(this, pane);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        output = new OutputAnchor(this, pane);
 
         parentPane.selectedBlockProperty()
                 .addListener(
@@ -66,7 +57,7 @@ public abstract class Block extends StackPane implements ComponentLoader {
 
         this.addEventHandler(MouseEvent.MOUSE_CLICKED, this::handleMouseEvent);
 
-        Platform.runLater(() -> (this.createCircleMenu()));
+        Platform.runLater(this::createCircleMenu);
     }
 
     protected void createCircleMenu() {

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -1,6 +1,5 @@
 package nl.utwente.group10.ui.components.blocks;
 
-import java.io.IOException;
 import java.util.Optional;
 
 import javafx.beans.property.SimpleStringProperty;
@@ -37,14 +36,13 @@ public class DisplayBlock extends Block {
     /**
      * Creates a new instance of DisplayBlock.
      * @param pane The pane on which this DisplayBlock resides.
-     * @throws IOException when the FXML definition for this block cannot be loaded.
      */
-    public DisplayBlock(CustomUIPane pane) throws IOException {
+    public DisplayBlock(CustomUIPane pane) {
         super(pane);
 
         output = new SimpleStringProperty("New Output");
 
-        this.getFXMLLoader("DisplayBlock").load();
+        this.loadFXML("DisplayBlock");
 
         inputAnchor = new InputAnchor(this, pane);
         anchorSpace.getChildren().add(inputAnchor);

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -1,6 +1,5 @@
 package nl.utwente.group10.ui.components.blocks;
 
-import java.io.IOException;
 import java.util.ArrayList;
 
 import javafx.beans.property.SimpleStringProperty;
@@ -45,15 +44,14 @@ public class FunctionBlock extends Block {
      * @param name The name of the function.
      * @param type The function's type (usually a FuncT).
      * @param pane The parent pane in which this FunctionBlock exists.
-     * @throws IOException when the FXML defenition for this Block cannot be loaded.
      */
-    public FunctionBlock(String name, Type type, CustomUIPane pane) throws IOException {
+    public FunctionBlock(String name, Type type, CustomUIPane pane) {
         super(pane);
 
         this.name = new SimpleStringProperty(name);
         this.type = new SimpleStringProperty(type.toHaskellType());
 
-        this.getFXMLLoader("FunctionBlock").load();
+        this.loadFXML("FunctionBlock");
 
         // Collect argument types
         ArrayList<String> args = new ArrayList<>();

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
@@ -1,7 +1,5 @@
 package nl.utwente.group10.ui.components.blocks;
 
-import java.io.IOException;
-
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
@@ -28,12 +26,12 @@ public class ValueBlock extends Block {
      * @param pane The parent pane this Block resides on.
      * @throws IOException when the FXML definition cannot be loaded.
      */
-    public ValueBlock(CustomUIPane pane) throws IOException {
+    public ValueBlock(CustomUIPane pane) {
         super(pane);
 
         value = new SimpleStringProperty("5.0");
 
-        this.getFXMLLoader("ValueBlock").load();
+        this.loadFXML("ValueBlock");
 
         outputSpace.getChildren().add(this.getOutputAnchor());
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/lines/ConnectionLine.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/lines/ConnectionLine.java
@@ -1,7 +1,5 @@
 package nl.utwente.group10.ui.components.lines;
 
-import java.io.IOException;
-
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Point2D;
 import javafx.scene.shape.CubicCurve;
@@ -28,16 +26,8 @@ public class ConnectionLine extends CubicCurve implements ComponentLoader {
     public static final double BEZIER_CONTROL_OFFSET_MINIMUM = 10f;
     public static final double BEZIER_CONTROL_OFFSET_MAXIMUM = 200f;
 
-    /** The fxmlLoader responsible for loading the fxml. */
-    private FXMLLoader fxmlLoader;
-
     public ConnectionLine() {
-            try {
-                getFXMLLoader("ConnectionLine").load();
-            } catch (IOException e) {
-                // TODO Find a good way to handle this
-                e.printStackTrace();
-            }
+        this.loadFXML("ConnectionLine");
 
         TactilePane.setDraggable(this, false);
         TactilePane.setGoToForegroundOnContact(this, false);

--- a/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
@@ -1,9 +1,7 @@
 package nl.utwente.group10.ui.menu;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 
 import javafx.geometry.Point2D;
 import javafx.scene.control.ContextMenu;
@@ -38,15 +36,15 @@ public class MainMenu extends ContextMenu {
                 MenuItem item = new MenuItem(entry.getName());
                 item.setOnAction(event -> addFunctionBlock(entry));
                 submenu.getItems().add(item);
-        }
+            }
 
             this.getItems().addAll(submenu);
         }
 
         MenuItem valueBlockItem = new MenuItem("Value Block");
-        valueBlockItem.setOnAction(event -> addValueBlock());
+        valueBlockItem.setOnAction(event -> addBlock(new ValueBlock(parent)));
         MenuItem displayBlockItem = new MenuItem("Display Block");
-        displayBlockItem.setOnAction(event -> addDisplayBlock());
+        displayBlockItem.setOnAction(event -> addBlock(new DisplayBlock(parent)));
         
         //TODO remove this item when debugging of visualFeedback is done
         MenuItem errorItem = new MenuItem("Error all Blocks");
@@ -61,28 +59,8 @@ public class MainMenu extends ContextMenu {
     }
 
     private void addFunctionBlock(FunctionEntry entry) {
-        try {
-            FunctionBlock fb = new FunctionBlock(entry.getName(), entry.asHaskellObject(new Context()), parent); // TODO: Once the Env is available, the type should be pulled from the Env here (don't just calculate it over and over). Or just pass the signature String.
-            addBlock(fb);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void addValueBlock() {
-        try {
-            addBlock(new ValueBlock(parent));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void addDisplayBlock() {
-        try {
-            addBlock(new DisplayBlock(parent));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        FunctionBlock fb = new FunctionBlock(entry.getName(), entry.asHaskellObject(new Context()), parent); // TODO: Once the Env is available, the type should be pulled from the Env here (don't just calculate it over and over). Or just pass the signature String.
+        addBlock(fb);
     }
 
     private void addBlock(Block block) {


### PR DESCRIPTION
This changes the ComponentLoader interface to itself catch IOExceptions
and rethrow them as RuntimeExceptions.

Not throwing IOExceptions simplifies quite a few methods, as well as the
MainMenu class.

Rationale: When an FXML file can not be read, that's *always* a fatal
error. In other words, the program is useless when it does not have all
its FXML files. In the old implementation, none of the places that
caught the exception did something useful with it.