### PR TITLE
Fix contains check in TypeClass (with compareTo)

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/haskell/type/TypeClass.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/TypeClass.java
@@ -48,7 +48,7 @@ public class TypeClass extends HaskellObject {
      * @return Whether the given type is in this type class.
      */
     public final boolean hasType(Type type) {
-        return this.types.contains(type);
+        return this.types.stream().anyMatch(t -> t.compareTo(type) == 0);
     }
 
     public final String toString() {


### PR DESCRIPTION
Set.contains returns true if its argument is equal to any of the set's
elements, but we do not override equals() or hashCode() on Type. We do
implement Comparable, however, so that is what we use here.

Complexity gone from possible O(1) to definite O(N), but N is small.