### PR TITLE
Have FunctionBlock.getOutputType always analyze()

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -1,9 +1,9 @@
 package nl.utwente.group10.ui.components.blocks;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.common.collect.ImmutableList;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
@@ -131,24 +131,7 @@ public class DisplayBlock extends Block implements InputBlock {
 
     @Override
     public List<InputAnchor> getInputs() {
-        List<InputAnchor> list = new ArrayList<>();
-        list.add(inputAnchor);
-        return list;
-    }
-
-    @Override
-    public int getInputIndex(InputAnchor anchor) {
-        return 0;
-    }
-
-    @Override
-    public boolean inputsAreConnected() {
-        return inputIsConnected(0);
-    }
-
-    @Override
-    public boolean inputIsConnected(int index) {
-        return inputAnchor.isConnected();
+        return ImmutableList.of(inputAnchor);
     }
 
     public void error() {

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -107,16 +107,6 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     }
 
     /**
-     * Nest another {@link Node} object within this FunctionBlock
-     *
-     * @param node
-     *            The node to nest.
-     */
-    public final void nest(Node node) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      * @param name
      *            The name of this FunctionBlock
      */
@@ -130,18 +120,6 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
      */
     public final void setType(String type) {
         this.type.set(type);
-    }
-
-    /**
-     * Returns the index of the argument matched to the Anchor.
-     *
-     * @param anchor
-     *            The anchor to look up.
-     * @return The index of the given Anchor in the input anchor array.
-     */
-    @Override
-    public final int getInputIndex(InputAnchor anchor) {
-        return inputs.indexOf(anchor);
     }
 
     /** Returns the array of input anchors for this function block. */
@@ -167,16 +145,6 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     /** Returns the StringProperty for the type of the function. */
     public final StringProperty typeProperty() {
         return type;
-    }
-
-    @Override
-    public boolean inputsAreConnected() {
-        return inputs.stream().allMatch(ConnectionAnchor::isConnected);
-    }
-
-    @Override
-    public boolean inputIsConnected(int index) {
-        return index>=0 && index < inputs.size() && inputs.get(index).isConnected();
     }
 
     /**
@@ -261,14 +229,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     @Override
     public Type getOutputType(Env env) {
         try {
-            Type type;
-            // TODO dynamically update (unify) output type with available
-            // information.
-            if (inputsAreConnected()) {
-                type = asExpr().analyze(env).prune();
-            } else {
-                type = getFunctionSignature();
-            }
+            Type type = asExpr().analyze(env).prune();
 
             while (type instanceof ConstT
                     && ((ConstT) type).getArgs().length == 2) {

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/InputBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/InputBlock.java
@@ -8,14 +8,14 @@ import nl.utwente.group10.ui.components.anchors.InputAnchor;
 public interface InputBlock {
     /*
      * Signature = non unified type, ie: a->b
-     * 
+     *
      * (Current)Type = unified type, ie Int -> Float (This can still have
      * signature a->b)
-     * 
+     *
      * These are not the same, but are related. The Type has to conform to the
      * signature.
      */
-    
+
     /**
      * @param input
      *            The argument of which the type is desired.
@@ -42,16 +42,7 @@ public interface InputBlock {
     /**
      * @return The index the specified anchor has (in getInputs())
      */
-    public int getInputIndex(InputAnchor anchor);
-
-    /**
-     * @return True if inputIsConnected() for all inputs.
-     */
-    public boolean inputsAreConnected();
-
-    /**
-     * @return True if the specified input is fully connected, ie has a
-     *         connection to another output anchor.
-     */
-    public boolean inputIsConnected(int index);
+    default int getInputIndex(InputAnchor anchor) {
+        return getInputs().indexOf(anchor);
+    }
 }


### PR DESCRIPTION
The current implementation has getOutputType skip analyzing if one or more inputs of the function block are not connected. However, we might not need the disconnected input to say something sensible about the output type. So instead of this:

![2015-05-08-184615_638x453_scrot](https://cloud.githubusercontent.com/assets/126832/7541046/82eb9b08-f5b2-11e4-9c29-b9b4f6c34c7c.png)

The PR tells FunctionBlock to always analyze:

![2015-05-08-184643_817x528_scrot](https://cloud.githubusercontent.com/assets/126832/7541048/8852dea8-f5b2-11e4-938a-dd7cdc5964b0.png)

As an added bonus, not having to be able to check if inputs are connected simplifies the InputBlock interface a bit.