### PR TITLE
Ui types bowtie

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -130,10 +130,15 @@ public class DisplayBlock extends Block implements InputBlock {
     }
 
     @Override
-    public List<InputAnchor> getInputs() {
+    public List<InputAnchor> getAllInputs() {
         List<InputAnchor> list = new ArrayList<>();
         list.add(inputAnchor);
         return list;
+    }
+
+    @Override
+    public List<InputAnchor> getActiveInputs() {
+        return getAllInputs();
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -5,6 +5,10 @@ import java.util.List;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -12,12 +16,9 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
 import nl.utwente.group10.haskell.expr.Apply;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Ident;
-import nl.utwente.group10.haskell.hindley.GenSet;
-import nl.utwente.group10.haskell.type.ConstT;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.ui.BackendUtils;
@@ -32,9 +33,15 @@ import nl.utwente.group10.ui.exceptions.TypeUnavailableException;
  * Main building block for the visual interface, this class represents a Haskell
  * function together with it's arguments and visual representation.
  */
-public class FunctionBlock extends Block implements InputBlock, OutputBlock {
+public class FunctionBlock extends Block implements InputBlock, OutputBlock, ChangeListener<Number> {
     /** The inputs for this FunctionBlock. **/
     private List<InputAnchor> inputs;
+
+    /**
+     * The index of the bowtie, all inputs with index higher or equal to the
+     * bowtie are be inactive.
+     */
+    private IntegerProperty bowtieIndex;
 
     private OutputAnchor output;
 
@@ -76,6 +83,8 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
 
         this.name = new SimpleStringProperty(name);
         this.type = new SimpleStringProperty(type.toHaskellType());
+        this.bowtieIndex = new SimpleIntegerProperty();
+        bowtieIndex.addListener(this);
 
         this.loadFXML("FunctionBlock");
 
@@ -97,6 +106,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
 
             argumentSpace.getChildren().add(new Label(args.get(i)));
         }
+        setBowtieIndex(getAllInputs().size());
 
         // Create an anchor and label for the result
         Label lbl = new Label(t.toHaskellType());
@@ -133,6 +143,16 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     }
 
     /**
+     * @param index
+     *            The new bowtie index for this FunctionBlock.
+     */
+    public final void setBowtieIndex(int index) {
+        if (index >= 0 && index <= getAllInputs().size()) {
+            this.bowtieIndex.set(index);
+        }
+    }
+
+    /**
      * Returns the index of the argument matched to the Anchor.
      *
      * @param anchor
@@ -145,8 +165,16 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     }
 
     /** Returns the array of input anchors for this function block. */
-    public final List<InputAnchor> getInputs() {
+    public final List<InputAnchor> getAllInputs() {
         return inputs;
+    }
+    
+    /**
+     * @return Only the active (as specified with the bowtie) inputs.
+     */
+    @Override
+    public List<InputAnchor> getActiveInputs() {
+        return inputs.subList(0, getBowtieIndex());
     }
 
     /** Returns the name property of this FunctionBlock. */
@@ -159,6 +187,11 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
         return type.get();
     }
 
+    /** Returns the bowtie index of this FunctionBlock. */
+    public final Integer getBowtieIndex() {
+        return bowtieIndex.get();
+    }
+
     /** Returns the StringProperty for the name of the function. */
     public final StringProperty nameProperty() {
         return name;
@@ -169,14 +202,23 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
         return type;
     }
 
+    /** Returns the IntegerPorperty for the bowtie index of this FunctionBlock. */
+    public final IntegerProperty bowtieIndexProperty() {
+        return bowtieIndex;
+    }
+
     @Override
     public boolean inputsAreConnected() {
-        return inputs.stream().allMatch(ConnectionAnchor::isConnected);
+        boolean connected = true;
+        for (int i = 0; i < getBowtieIndex(); i++) {
+            connected = connected && getAllInputs().get(i).isConnected();
+        }
+        return connected;
     }
 
     @Override
     public boolean inputIsConnected(int index) {
-        return index>=0 && index < inputs.size() && inputs.get(index).isConnected();
+        return index>=0 && index < getBowtieIndex() && inputs.get(index).isConnected();
     }
 
     /**
@@ -185,8 +227,8 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     @Override
     public final Expr asExpr() {
         Expr expr = new Ident(getName());
-        for (InputAnchor in : getInputs()) {
-            expr = new Apply(expr, in.asExpr());
+        for ( int i = 0; i < getBowtieIndex(); i++){
+            expr = new Apply(expr, getAllInputs().get(i).asExpr());
         }
 
         return expr;
@@ -211,8 +253,8 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     @Override
     public Type getInputSignature(int index) {
         if (index >= 0 && index < inputs.size()) {
-            if (getFunctionSignature() instanceof ConstT) {
-                return BackendUtils.dive((ConstT) getFunctionSignature(), index + 1);
+            if (getFunctionSignature() instanceof FuncT) {
+                return BackendUtils.dive((FuncT) getFunctionSignature(), index + 1);
             } else {
                 throw new FunctionDefinitionException();
             }
@@ -228,8 +270,8 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
 
     @Override
     public Type getInputType(int index) {
-        if (getInputs().get(index).isConnected()) {
-            return getInputs().get(index).getOtherAnchor().get().getType();
+        if (getAllInputs().get(index).isConnected()) {
+            return getAllInputs().get(index).getOtherAnchor().get().getType();
         } else {
             return getInputSignature(index);
         }
@@ -243,9 +285,9 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     @Override
     public Type getOutputSignature(Env env) {
         Type type = getFunctionSignature();
-        for (int i = 0; i < getInputs().size(); i++) {
-            if (type instanceof ConstT) {
-                type = ((ConstT) type).getArgs()[1];
+        for (int i = 0; i < getBowtieIndex(); i++) {
+            if (type instanceof FuncT) {
+                type = ((FuncT) type).getArgs()[1];
             } else {
                 throw new FunctionDefinitionException();
             }
@@ -261,20 +303,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     @Override
     public Type getOutputType(Env env) {
         try {
-            Type type;
-            // TODO dynamically update (unify) output type with available
-            // information.
-            if (inputsAreConnected()) {
-                type = asExpr().analyze(env).prune();
-            } else {
-                type = getFunctionSignature();
-            }
-
-            while (type instanceof ConstT
-                    && ((ConstT) type).getArgs().length == 2) {
-                type = ((ConstT) type).getArgs()[1];
-            }
-            return type;
+            return asExpr().analyze(env).prune();
         } catch (HaskellException e) {
             e.printStackTrace();
             return getOutputSignature();
@@ -297,7 +326,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
      */
     private void invalidateInput() {
         List<Label> labels = new ArrayList<Label>();
-        for (int i = 0; i < getInputs().size(); i++) {
+        for (int i = 0; i < getBowtieIndex(); i++) {
             labels.add(new Label(getInputType(i).toHaskellType()));
         }
         inputTypesSpace.getChildren().setAll(labels);
@@ -313,7 +342,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
 
     @Override
     public final void error() {
-        for (InputAnchor in : getInputs()) {
+        for (InputAnchor in : getAllInputs()) {
             if (!in.hasConnection()) {
                 argumentSpace.getChildren().get(getInputIndex(in)).getStyleClass().add("error");
             } else if (in.hasConnection()) {
@@ -326,5 +355,21 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     @Override
     public OutputAnchor getOutputAnchor() {
         return output;
+    }
+
+    @Override
+    public void changed(ObservableValue<? extends Number> arg0, Number arg1, Number arg2) {
+        if (arg0.equals(bowtieIndex)) {
+            invalidateBowtieIndex();
+        }
+    }
+
+    private void invalidateBowtieIndex() {
+        for (InputAnchor input : getAllInputs()) {
+            input.setVisible(getInputIndex(input) < getBowtieIndex());
+            if(input.isConnected()){
+                input.getConnection().get().disconnect();
+            }
+        }
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -209,16 +209,12 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock, Cha
 
     @Override
     public boolean inputsAreConnected() {
-        boolean connected = true;
-        for (int i = 0; i < getBowtieIndex(); i++) {
-            connected = connected && getAllInputs().get(i).isConnected();
-        }
-        return connected;
+        return getActiveInputs().stream().allMatch(ConnectionAnchor::isConnected);
     }
 
     @Override
     public boolean inputIsConnected(int index) {
-        return index>=0 && index < getBowtieIndex() && inputs.get(index).isConnected();
+        return index >= 0 && index < getBowtieIndex() && inputs.get(index).isConnected();
     }
 
     /**
@@ -227,8 +223,8 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock, Cha
     @Override
     public final Expr asExpr() {
         Expr expr = new Ident(getName());
-        for ( int i = 0; i < getBowtieIndex(); i++){
-            expr = new Apply(expr, getAllInputs().get(i).asExpr());
+        for (InputAnchor in : getActiveInputs()) {
+            expr = new Apply(expr, in.asExpr());
         }
 
         return expr;

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/InputBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/InputBlock.java
@@ -35,9 +35,14 @@ public interface InputBlock {
     public Type getInputType(int index);
 
     /**
-     * @return The inputs of the block.
+     * @return All inputs of the block.
      */
-    public List<InputAnchor> getInputs();
+    public List<InputAnchor> getAllInputs();
+    
+    /**
+     * @return Only the active (as specified with the bowtie) inputs.
+     */
+    public List<InputAnchor> getActiveInputs();
 
     /**
      * @return The index the specified anchor has (in getInputs())

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
@@ -10,6 +10,7 @@ import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.haskell.expr.Value;
 import nl.utwente.group10.haskell.hindley.GenSet;
+import nl.utwente.group10.haskell.hindley.HindleyMilner;
 
 import org.junit.Test;
 
@@ -37,5 +38,33 @@ public class ApplyTest {
         Expr e4 = new Apply(e2, e3);
         Type t4 = e4.analyze(env).prune();
         assertEquals("Float", t4.toHaskellType());
+    }
+    
+    @Test
+    public void testApplyUndefined() throws CatalogException, HaskellException {
+        Env env = new HaskellCatalog().asEnvironment();
+        
+        Expr e0 = new Ident("(+)");
+        Type t0 = e0.analyze(env).prune();
+        assertEquals("((Num a) -> ((Num a) -> (Num a)))", t0.toHaskellType());
+        
+        Expr e1 = new Ident("undefined");
+        Type t1 = e1.analyze(env).prune();
+        HindleyMilner.unify(t1, new Value(new ConstT("Float"), "5.0").analyze(env));
+        // t1 Should unfiy with everything (the type of t1 should be 'a').
+        // No exception thrown -> Types are the same, as expected. The test will
+        // fail if an Exception is thrown.
+        
+        
+        Expr e2 = new Apply(e0, e1);
+        Type t2 = e2.analyze(env).prune();
+        assertEquals("(a -> a)", t2.toHaskellType());
+        
+        Expr e3 = new Apply(e2, new Ident("undefined"));
+        Type t3 = e3.analyze(env).prune();
+        HindleyMilner.unify(t3, new Value(new ConstT("Float"), "5.0").analyze(env));
+        // t3 Should unfiy with everything (the type of t3 should be 'a').
+        // No exception thrown -> Types are the same, as expected. The test will
+        // fail if an Exception is thrown.
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
@@ -10,7 +10,6 @@ import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.haskell.expr.Value;
 import nl.utwente.group10.haskell.hindley.GenSet;
-import nl.utwente.group10.haskell.hindley.HindleyMilner;
 
 import org.junit.Test;
 
@@ -38,33 +37,5 @@ public class ApplyTest {
         Expr e4 = new Apply(e2, e3);
         Type t4 = e4.analyze(env).prune();
         assertEquals("Float", t4.toHaskellType());
-    }
-    
-    @Test
-    public void testApplyUndefined() throws CatalogException, HaskellException {
-        Env env = new HaskellCatalog().asEnvironment();
-        
-        Expr e0 = new Ident("(+)");
-        Type t0 = e0.analyze(env).prune();
-        assertEquals("((Num a) -> ((Num a) -> (Num a)))", t0.toHaskellType());
-        
-        Expr e1 = new Ident("undefined");
-        Type t1 = e1.analyze(env).prune();
-        HindleyMilner.unify(t1, new Value(new ConstT("Float"), "5.0").analyze(env));
-        // t1 Should unfiy with everything (the type of t1 should be 'a').
-        // No exception thrown -> Types are the same, as expected. The test will
-        // fail if an Exception is thrown.
-        
-        
-        Expr e2 = new Apply(e0, e1);
-        Type t2 = e2.analyze(env).prune();
-        assertEquals("(a -> a)", t2.toHaskellType());
-        
-        Expr e3 = new Apply(e2, new Ident("undefined"));
-        Type t3 = e3.analyze(env).prune();
-        HindleyMilner.unify(t3, new Value(new ConstT("Float"), "5.0").analyze(env));
-        // t3 Should unfiy with everything (the type of t3 should be 'a').
-        // No exception thrown -> Types are the same, as expected. The test will
-        // fail if an Exception is thrown.
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/ui/components/blocks/FunctionBlockTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ui/components/blocks/FunctionBlockTest.java
@@ -48,7 +48,7 @@ public class FunctionBlockTest extends ComponentTest {
      */
     @Test
     public void inputsTest() {
-        assertNotNull(functionBlock.getInputs());
-        assertEquals(functionBlock.getInputs().size(), 2);
+        assertNotNull(functionBlock.getAllInputs());
+        assertEquals(functionBlock.getAllInputs().size(), 2);
     }
 }


### PR DESCRIPTION
Hierbij een PR dat FunctionBlocks ondersteuning geeft voor een bowtie.
Er is nog geen ui besturing om deze bowtie te veranderen (of uberhaupt weer te geven), maar FunctionBlock heeft nu een property die de index van de bowtie specifieerd, en alle types e.d. houden hier nu rekening mee.

Daarbij heb ik een nieuwe bug gevonden in de backend, het opvragen van het type van "(+) undefined" geeft een error, wat volgens gchi een 'Num a => a -> a' moet zijn.

Ik weet niet of het handig is die test hier bij in te doen, graag zou ik willen weten wat hier de handigste werkwijze voor is.