### PR TITLE
Efficient Invalidation, ConnectionAnchors now always have a list of connections

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -137,9 +137,9 @@ public class CustomUIPane extends TactilePane {
 
     /**
      * Re-evaluate all display blocks.
+     * This is inefficient.
      */
     public final void invalidateAll() {
-        System.out.println("Using inefficient invalidation!");
         for (Node node : getChildren()) {
             if (node instanceof Block) {
                 ((Block) node).invalidateConnectionState();

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -142,7 +142,7 @@ public class CustomUIPane extends TactilePane {
         System.out.println("Using inefficient invalidation!");
         for (Node node : getChildren()) {
             if (node instanceof Block) {
-                ((Block) node).invalidateConnectionVisuals();
+                ((Block) node).invalidateConnectionState();
             }
         }
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -138,10 +138,11 @@ public class CustomUIPane extends TactilePane {
     /**
      * Re-evaluate all display blocks.
      */
-    public final void invalidate() {
+    public final void invalidateAll() {
+        System.out.println("Using inefficient invalidation!");
         for (Node node : getChildren()) {
             if (node instanceof Block) {
-                ((Block) node).invalidate();
+                ((Block) node).invalidateConnectionVisuals();
             }
         }
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -79,7 +79,7 @@ public class Main extends Application {
         displayBlock.relocate(tactilePane.getWidth() / 2, tactilePane.getHeight() / 2 + 100);
 
         // Invalidate
-        tactilePane.invalidate();
+        tactilePane.invalidateAll();
         tactilePane.requestFocus();
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
@@ -49,19 +49,23 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
     public abstract Type getType();
 
     /**
-     * Disconnects the anchor from the connection
+     * Removes the connection from its pane, first disconnecting it from its anchors.
      *
      * @param connection
-     *            Connection to disconnect from.
+     *            Connection to remove from its pane.
      */
     public void removeConnection(Connection connection) {
         if (connections.contains(connection)) {
             connections.remove(connection);
-            getPane().getChildren().remove(connection);
-            connection.disconnect();
+            connection.remove();
         }
     }
-    
+    /**
+     * Disconnects the anchor from the connection, keeping the connection on its pane.
+     *
+     * @param connection
+     *            Connection to disconnect from.
+     */
     public void disconnectConnection(Connection connection) {
         if (connections.contains(connection)) {
             connections.remove(connection);
@@ -69,15 +73,15 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
         }
     }
     
-    public void clearConnections(){
-        for (int i = 0; i < getConnections().size(); i++) {
-            removeConnection(getConnections().get(0));
+    public void removeConnections(){
+        while(connections.size() > 0){
+            removeConnection(connections.get(0));
         }
     }
     
     public void disconnectConnections(){
-        for (int i = 0; i < getConnections().size(); i++) {
-            disconnectConnection(getConnections().get(0));
+        while(connections.size() > 0){
+            disconnectConnection(connections.get(0));
         }
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
@@ -119,6 +119,7 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
      * @param index
      *            Index of the connection to check
      * @return Wether or not the connection specified by the index is connected.
+     *         Returns false if the index is out of bounds.
      */
     public boolean isConnected(int index) {
         return index >= 0 && index < getConnections().size() && getConnections().get(index).isConnected();

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
@@ -79,7 +79,7 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
      * Removes all the connections this anchor has.
      */
     public void removeConnections() {
-        while (connections.size() > 0) {
+        while (!connections.isEmpty()) {
             removeConnection(connections.get(0));
         }
     }
@@ -88,7 +88,7 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
      * Disconnects all the connections this anchor has from this anchor.
      */
     public void disconnectConnections() {
-        while (connections.size() > 0) {
+        while (!connections.isEmpty()) {
             disconnectConnection(connections.get(0));
         }
     }
@@ -105,7 +105,7 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
 
     /** Returns true this anchor has 1 or more connections. */
     public boolean hasConnection() {
-        return connections.size() > 0;
+        return !connections.isEmpty();
     }
 
     /**
@@ -114,12 +114,13 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
     public boolean isPrimaryConnected() {
         return isConnected(0);
     }
-    
+
     /**
-     * @param index Index of the connection to check
+     * @param index
+     *            Index of the connection to check
      * @return Wether or not the connection specified by the index is connected.
      */
-    public boolean isConnected(int index){
+    public boolean isConnected(int index) {
         return index >= 0 && index < getConnections().size() && getConnections().get(index).isConnected();
     }
 
@@ -127,34 +128,37 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
     public abstract boolean canAddConnection();
 
     /**
-     * This method provides a shortcut to get the anchors on the other side of the Connection from this anchor.
-     * @return A list of each potential opposite anchor for each Connection this anchor has.
+     * This method provides a shortcut to get the anchors on the other side of
+     * the Connection from this anchor.
+     * 
+     * @return A list of each potential opposite anchor for each Connection this
+     *         anchor has.
      */
     public List<Optional<? extends ConnectionAnchor>> getOppositeAnchors() {
         List<Optional<? extends ConnectionAnchor>> list = new ArrayList<Optional<? extends ConnectionAnchor>>();
-        for(Connection c : getConnections()){
-            if(c.isConnected()){
-                if(c.getInputAnchor().isPresent() && c.getInputAnchor().get().equals(this)){
+        for (Connection c : getConnections()) {
+            if (c.isConnected()) {
+                if (c.getInputAnchor().isPresent() && c.getInputAnchor().get().equals(this)) {
                     list.add(c.getOutputAnchor());
-                }else if(c.getOutputAnchor().isPresent() && c.getOutputAnchor().get().equals(this)){
+                } else if (c.getOutputAnchor().isPresent() && c.getOutputAnchor().get().equals(this)) {
                     list.add(c.getInputAnchor());
-                }else{
+                } else {
                     list.add(Optional.empty());
                 }
-            }else{
+            } else {
                 list.add(Optional.empty());
             }
         }
         return list;
     }
-    
+
     /**
      * @return Just the primary's opposite anchor.
      */
-    public Optional<? extends ConnectionAnchor> getPrimaryOppositeAnchor(){
-        if(getOppositeAnchors().size()>0){
+    public Optional<? extends ConnectionAnchor> getPrimaryOppositeAnchor() {
+        if (!getOppositeAnchors().isEmpty()) {
             return getOppositeAnchors().get(0);
-        }else{
+        } else {
             return Optional.empty();
         }
     }
@@ -164,18 +168,18 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
         return block;
     }
 
-    /** Returns the connections this anchor is connected to.*/
+    /** Returns the connections this anchor is connected to. */
     public List<Connection> getConnections() {
         return connections;
     }
-    
+
     /**
      * @return The primary connection.
      */
-    public Optional<Connection> getPrimaryConnection(){
-        if(getConnections().size()>0){
+    public Optional<Connection> getPrimaryConnection() {
+        if (getConnections().size() > 0) {
             return Optional.of(getConnections().get(0));
-        }else{
+        } else {
             return Optional.empty();
         }
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
@@ -13,11 +13,10 @@ import nl.utwente.group10.ui.components.blocks.Block;
 import nl.utwente.group10.ui.components.lines.Connection;
 
 /**
- * Represent an Anchor point on either a Block or a Line Integers are currently
- * the only supported data type.
- * <p>
- * Other data types will be supported in the future.
- * </p>
+ * Represents an anchor of a Block that can connect to (1 or more) Connections.
+ * 
+ * The primary Connection (if present) is the first element in getConnections().
+ * This means that the oldest Connection is the primary connection.
  */
 public abstract class ConnectionAnchor extends Circle implements ComponentLoader {
     /** The pane on which this Anchor resides. */

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/ConnectionAnchor.java
@@ -26,7 +26,7 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
     /** The block this Anchor is connected to. */
     private Block block;
 
-    /** The possible connection linked to this anchor */
+    /** The connections this anchor has, can be empty for no connections. */
     private List<Connection> connections;
 
     /**
@@ -49,7 +49,8 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
     public abstract Type getType();
 
     /**
-     * Removes the connection from its pane, first disconnecting it from its anchors.
+     * Removes the connection from its pane, first disconnecting it from its
+     * anchors.
      *
      * @param connection
      *            Connection to remove from its pane.
@@ -60,8 +61,10 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
             connection.remove();
         }
     }
+
     /**
-     * Disconnects the anchor from the connection, keeping the connection on its pane.
+     * Disconnects the connection from this anchor, keeping the connection on
+     * its pane.
      *
      * @param connection
      *            Connection to disconnect from.
@@ -72,46 +75,56 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
             connection.disconnect(this);
         }
     }
-    
-    public void removeConnections(){
-        while(connections.size() > 0){
+
+    /**
+     * Removes all the connections this anchor has.
+     */
+    public void removeConnections() {
+        while (connections.size() > 0) {
             removeConnection(connections.get(0));
         }
     }
-    
-    public void disconnectConnections(){
-        while(connections.size() > 0){
+
+    /**
+     * Disconnects all the connections this anchor has from this anchor.
+     */
+    public void disconnectConnections() {
+        while (connections.size() > 0) {
             disconnectConnection(connections.get(0));
         }
     }
 
     /**
-     * Set the connection this anchor is connected to.
-     *
+     * Adds the given connection to the connections this anchor has.
+     * 
      * @param connection
+     *            Connection to add
      */
     public void addConnection(Connection connection) {
         connections.add(connection);
     }
 
-    /** Returns true if the anchor is connected to a connection. */
+    /** Returns true this anchor has 1 or more connections. */
     public boolean hasConnection() {
         return connections.size() > 0;
     }
 
     /**
-     * @return True if this ConnectionAnchor is connected to a Connection and
-     *         that connection is fully connected.
+     * @return True if the primary connection is connected.
      */
     public boolean isPrimaryConnected() {
         return isConnected(0);
     }
     
+    /**
+     * @param index Index of the connection to check
+     * @return Wether or not the connection specified by the index is connected.
+     */
     public boolean isConnected(int index){
         return index >= 0 && index < getConnections().size() && getConnections().get(index).isConnected();
     }
 
-    /** Returns true if this anchor can connect to a connection. */
+    /** Wether or not this anchor allows adding an extra connection. */
     public abstract boolean canAddConnection();
 
     /**
@@ -136,6 +149,9 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
         return list;
     }
     
+    /**
+     * @return Just the primary's opposite anchor.
+     */
     public Optional<? extends ConnectionAnchor> getPrimaryOppositeAnchor(){
         if(getOppositeAnchors().size()>0){
             return getOppositeAnchors().get(0);
@@ -149,11 +165,14 @@ public abstract class ConnectionAnchor extends Circle implements ComponentLoader
         return block;
     }
 
-    /** Returns the connection this anchor is connected to. (if any) */
+    /** Returns the connections this anchor is connected to.*/
     public List<Connection> getConnections() {
         return connections;
     }
     
+    /**
+     * @return The primary connection.
+     */
     public Optional<Connection> getPrimaryConnection(){
         if(getConnections().size()>0){
             return Optional.of(getConnections().get(0));

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
@@ -2,6 +2,7 @@ package nl.utwente.group10.ui.components.anchors;
 
 import java.util.Optional;
 
+import edu.emory.mathcs.backport.java.util.Arrays;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.haskell.type.Type;
@@ -33,8 +34,8 @@ public class InputAnchor extends ConnectionAnchor {
      *         anchor.
      */
     public final Expr asExpr() {
-        if (isConnected()) {
-            return getOtherAnchor().get().getBlock().asExpr();
+        if (isPrimaryConnected()) {
+            return getPrimaryOppositeAnchor().get().getBlock().asExpr();
         } else {
             return new Ident("undefined");
         }
@@ -51,23 +52,17 @@ public class InputAnchor extends ConnectionAnchor {
      */
     public Optional<Connection> createConnectionFrom(OutputAnchor other) {
         if (!hasConnection()) {
-            new Connection(getPane(), this, other);
-            getPane().getChildren().add(getConnection().get());
+            Connection connection = new Connection(getPane(), this, other);
+            getPane().getChildren().add(connection);
             getPane().invalidate();
-            return getConnection();
+            return Optional.of(connection);
         } else {
             return Optional.empty();
         }
     }
 
     @Override
-    public void removeConnection(Connection connection) {
-        assert connection.equals(getConnection().get());
-        setConnection(null);
-    }
-
-    @Override
-    public boolean canConnect() {
+    public boolean canAddConnection() {
         // InputAnchors only support 1 connection;
         return !hasConnection();
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
@@ -54,7 +54,6 @@ public class InputAnchor extends ConnectionAnchor {
         if (!hasConnection()) {
             Connection connection = new Connection(getPane(), this, other);
             getPane().getChildren().add(connection);
-            getPane().invalidate();
             return Optional.of(connection);
         } else {
             return Optional.empty();

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
@@ -41,25 +41,6 @@ public class InputAnchor extends ConnectionAnchor {
         }
     }
 
-    /**
-     * Creates a {@link Connection} from another anchor to this one and returns
-     * the connection. If the current anchor is already part of a connection it
-     * returns {@link Optional#empty()}.
-     *
-     * @param other
-     *            The other anchor to establish a connection to.
-     * @return The connection or Optional.empty()
-     */
-    public Optional<Connection> createConnectionFrom(OutputAnchor other) {
-        if (!hasConnection()) {
-            Connection connection = new Connection(getPane(), this, other);
-            getPane().getChildren().add(connection);
-            return Optional.of(connection);
-        } else {
-            return Optional.empty();
-        }
-    }
-
     @Override
     public boolean canAddConnection() {
         // InputAnchors only support 1 connection;

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
@@ -34,27 +34,16 @@ public class OutputAnchor extends ConnectionAnchor {
      * @return {@link Optional#empty()}
      */
     public Connection createConnectionTo(InputAnchor other) {
-        new Connection(getPane(), this, other);
-        getPane().getChildren().add(getConnection().get());
+        Connection connection = new Connection(getPane(), this, other);
+        getPane().getChildren().add(connection);
         getPane().invalidate();
-        return getConnection().get();
+        return connection;
     }
 
     @Override
-    public void removeConnection(Connection connection) {
-        // Currently does not keep track of its connections.
-    }
-
-    @Override
-    public boolean canConnect() {
+    public boolean canAddConnection() {
         // OutputAnchors can have multiple connections;
         return true;
-    }
-
-    @Override
-    public Optional<Connection> getConnection() {
-        // Does not keep track of its connections.
-        return Optional.empty();
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
@@ -25,20 +25,6 @@ public class OutputAnchor extends ConnectionAnchor {
         new AnchorHandler(pane.getConnectionCreationManager(), this);
     }
 
-    /**
-     * Creates a {@link Connection} to another anchor from this one and returns
-     * the connection.
-     *
-     * @param other
-     *            The other anchor to establish a connection to.
-     * @return {@link Optional#empty()}
-     */
-    public Connection createConnectionTo(InputAnchor other) {
-        Connection connection = new Connection(getPane(), this, other);
-        getPane().getChildren().add(connection);
-        return connection;
-    }
-
     @Override
     public boolean canAddConnection() {
         // OutputAnchors can have multiple connections;

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
@@ -36,7 +36,6 @@ public class OutputAnchor extends ConnectionAnchor {
     public Connection createConnectionTo(InputAnchor other) {
         Connection connection = new Connection(getPane(), this, other);
         getPane().getChildren().add(connection);
-        getPane().invalidate();
         return connection;
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -98,26 +98,26 @@ public abstract class Block extends StackPane implements ComponentLoader {
      *
      * This method should only be called after the Block's constructor is done.
      * 
-     * This method will refresh the visuals even if the state did not change.
+     * This method will invalidate the Block even if the state did not change.
      */
-    public void invalidateConnectionVisuals() {
+    public void invalidateConnectionState() {
     }
 
     /**
-     * Does the same as invalidateConnectionVisuals(), but cascading down to
+     * Does the same as invalidateConnectionState(), but cascading down to
      * other blocks which are possibly also (indirectly) affected by the state
      * change.
      * 
      * @param state
      *            The newest visual state
      */
-    public void invalidateConnectionVisualsCascading(int state) {
-        if (!connectionVisualsAreUpToDate(state)) {
-            invalidateConnectionVisuals();
+    public void invalidateConnectionStateCascading(int state) {
+        if (!connectionStateIsUpToDate(state)) {
+            invalidateConnectionState();
             if (this instanceof OutputBlock) {
                 for (Connection c : ((OutputBlock) this).getOutputAnchor().getConnections()) {
                     if (c.isConnected()) {
-                        c.getInputAnchor().get().getBlock().invalidateConnectionVisualsCascading(state);
+                        c.getInputAnchor().get().getBlock().invalidateConnectionStateCascading(state);
                     }
                 }
             }
@@ -126,16 +126,16 @@ public abstract class Block extends StackPane implements ComponentLoader {
     }
 
     /**
-     * Shortcut to call invalidateConnectionVisualsCascading(int state) with the newest state.
+     * Shortcut to call invalidateConnectionStateCascading(int state) with the newest state.
      */
-    public void invalidateConnectionVisualsCascading() {
-        invalidateConnectionVisualsCascading(ConnectionCreationManager.getConnectionState());
+    public void invalidateConnectionStateCascading() {
+        invalidateConnectionStateCascading(ConnectionCreationManager.getConnectionState());
     }
 
     /**
-     * @return Whether or not the visual state of the block confirms to the given newest state.
+     * @return Whether or not the state of the block confirms to the given newest state.
      */
-    public boolean connectionVisualsAreUpToDate(int state) {
+    public boolean connectionStateIsUpToDate(int state) {
         return this.visualState == state;
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -36,6 +36,9 @@ public abstract class Block extends StackPane implements ComponentLoader {
     private CustomUIPane parentPane;
     /** The context menu associated with this block instance. */
     private CircleMenu circleMenu;
+    
+    /** The visual state this Block is in */
+    private int visualState;
 
     /**
      * @param pane
@@ -93,8 +96,29 @@ public abstract class Block extends StackPane implements ComponentLoader {
      * change.
      *
      * This method should only be called after the Block's constructor is done.
+     * 
+     * This method will invalidate even if the state did not change.
      */
     public void invalidate() {
+    }
+    
+    /**
+     * This method will only invalidate and update the Blocks visuals if the state actually changed.
+     * 
+     * @param state The newest visual state
+     */
+    public void invalidate(int state) {
+        if(!visualsAreUpToDate(state)){
+            invalidate();
+        }
+        this.visualState = state;
+    }
+
+    /**
+     * @return Whether or not the visual state of the block confirms to the given newest state.
+     */
+    public boolean visualsAreUpToDate(int state) {
+        return this.visualState == state;
     }
 
     /** DEBUG METHOD trigger the error state for this block */

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -104,9 +104,11 @@ public abstract class Block extends StackPane implements ComponentLoader {
     }
 
     /**
-     * Does the same as invalidateConnectionState(), but cascading down to
-     * other blocks which are possibly also (indirectly) affected by the state
-     * change.
+     * Does the same as invalidateConnectionState(), but cascading down to other
+     * blocks which are possibly also (indirectly) affected by the state change.
+     * 
+     * Cascading only happens if this Block is not up-to-date, implying that if
+     * this Block is up-to-date, then so are all following Blocks.
      * 
      * @param state
      *            The newest visual state
@@ -117,7 +119,7 @@ public abstract class Block extends StackPane implements ComponentLoader {
             if (this instanceof OutputBlock) {
                 for (Connection c : ((OutputBlock) this).getOutputAnchor().getConnections()) {
                     if (c.isConnected()) {
-                        c.getInputAnchor().get().getBlock().invalidateConnectionStateCascading(state);
+                        c.getInputBlock().get().invalidateConnectionStateCascading(state);
                     }
                 }
             }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -101,8 +101,8 @@ public class DisplayBlock extends Block implements InputBlock {
 
     @Override
     public Type getInputType(InputAnchor anchor) {
-        if(anchor.getOtherAnchor().isPresent()) {
-            return anchor.getOtherAnchor().get().getType();
+        if(anchor.getPrimaryOppositeAnchor().isPresent()) {
+            return anchor.getPrimaryOppositeAnchor().get().getType();
         } else {
             return getInputSignature();
         }
@@ -148,7 +148,7 @@ public class DisplayBlock extends Block implements InputBlock {
 
     @Override
     public boolean inputIsConnected(int index) {
-        return inputAnchor.isConnected();
+        return inputAnchor.isPrimaryConnected();
     }
 
     public void error() {

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -87,7 +87,7 @@ public class DisplayBlock extends Block implements InputBlock {
     }
 
     /** Invalidates the outputted value and triggers re-evaluation of the value. */
-    public final void invalidate() {
+    public final void invalidateConnectionVisuals() {
         try {
             Optional<GhciSession> ghci = getPane().getGhciSession();
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -87,7 +87,7 @@ public class DisplayBlock extends Block implements InputBlock {
     }
 
     /** Invalidates the outputted value and triggers re-evaluation of the value. */
-    public final void invalidateConnectionVisuals() {
+    public final void invalidateConnectionState() {
         try {
             Optional<GhciSession> ghci = getPane().getGhciSession();
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -283,29 +283,16 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     }
 
     @Override
-    public void invalidate() {
+    public void invalidateConnectionVisuals() {
         // TODO not clear and re-add all labels every invalidate()
-        invalidateInput();
-        invalidateOutput();
-    }
-    
-    @Override
-    public void invalidate(int state) {
-        if (!visualsAreUpToDate(state)) {
-            for (Connection c : output.getConnections()) {
-                if(c.isConnected()){
-                    c.getInputAnchor().get().getBlock().invalidate(state);
-                }
-            }
-        }
-
-        super.invalidate(state);
+        invalidateInputVisuals();
+        invalidateOutputVisuals();
     }
 
     /**
      * Updates the input types to the Block's new state.
      */
-    private void invalidateInput() {
+    private void invalidateInputVisuals() {
         List<Label> labels = new ArrayList<Label>();
         for (int i = 0; i < getInputs().size(); i++) {
             labels.add(new Label(getInputType(i).toHaskellType()));
@@ -316,7 +303,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     /**
      * Updates the output types to the Block's new state.
      */
-    private void invalidateOutput() {
+    private void invalidateOutputVisuals() {
         Label label = new Label(getOutputType().toHaskellType());
         outputTypesSpace.getChildren().setAll(label);
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -283,7 +283,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     }
 
     @Override
-    public void invalidateConnectionVisuals() {
+    public void invalidateConnectionState() {
         // TODO not clear and re-add all labels every invalidate()
         invalidateInputVisuals();
         invalidateOutputVisuals();

--- a/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
@@ -22,7 +22,7 @@ import nl.utwente.group10.ui.handlers.ConnectionCreationManager;
  * <p>
  * It is possible for a connection to exist without both anchors being present,
  * whenever the position of either the start or end anchor changes the
- * {@link #invalidateConnectionVisuals()} should be called to refresh the visual
+ * {@link #invalidateConnectionState()} should be called to refresh the visual
  * representation of the connection.
  * </p>
  */
@@ -116,7 +116,7 @@ public class Connection extends ConnectionLine implements
                 System.out.println("Type mismatch!");
             }
         }
-        invalidateConnectionVisuals();
+        invalidateConnectionState();
 
         return added;
     }
@@ -194,7 +194,7 @@ public class Connection extends ConnectionLine implements
         }
 
         checkError();
-        invalidateConnectionVisualsCascading();
+        invalidateConnectionStateCascading();
     }
 
     /**
@@ -242,9 +242,12 @@ public class Connection extends ConnectionLine implements
     @Override
     public final void changed(ObservableValue<? extends Number> observable,
             Number oldValue, Number newValue) {
-        invalidateConnectionVisuals();
+        invalidateConnectionState();
     }
 
+    /**
+     * @return Whether or not both sides of this Connection are connected to an Anchor.
+     */
     public final boolean isConnected() {
         return startAnchor.isPresent() && endAnchor.isPresent();
     }
@@ -273,9 +276,9 @@ public class Connection extends ConnectionLine implements
         }
 
         //Let the now (potentially) disconnected block update its visuals.
-        anchor.getBlock().invalidateConnectionVisuals();
+        anchor.getBlock().invalidateConnectionState();
         //Let the remaining connected anchors update their visuals.
-        invalidateConnectionVisualsCascading();
+        invalidateConnectionStateCascading();
     }
     
     /**
@@ -290,7 +293,7 @@ public class Connection extends ConnectionLine implements
      * Runs both the update Start end End position functions. Use when
      * refreshing UI representation of the Line.
      */
-    private void invalidateConnectionVisuals() {
+    private void invalidateConnectionState() {
         startAnchor.ifPresent(a -> setStartPosition(a.getCenterInPane()));
         endAnchor.ifPresent(a -> setEndPosition(a.getCenterInPane()));
     }
@@ -303,17 +306,17 @@ public class Connection extends ConnectionLine implements
      * @param state
      *            The newest visual state
      */
-    public void invalidateConnectionVisualsCascading(int state) {
-        invalidateConnectionVisuals();
-        startAnchor.ifPresent(a -> a.getBlock().invalidateConnectionVisualsCascading(state));
-        endAnchor.ifPresent(a -> a.getBlock().invalidateConnectionVisualsCascading(state));
+    public void invalidateConnectionStateCascading(int state) {
+        invalidateConnectionState();
+        startAnchor.ifPresent(a -> a.getBlock().invalidateConnectionStateCascading(state));
+        endAnchor.ifPresent(a -> a.getBlock().invalidateConnectionStateCascading(state));
     }
 
     /**
      * Shortcut to call invalidateConnectionVisualsCascading(int state) with the newest state.
      */
-    public void invalidateConnectionVisualsCascading() {
-        invalidateConnectionVisualsCascading(ConnectionCreationManager.getConnectionState());
+    public void invalidateConnectionStateCascading() {
+        invalidateConnectionStateCascading(ConnectionCreationManager.getConnectionState());
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/group10/ui/exceptions/InvalidInputIdException.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/exceptions/InvalidInputIdException.java
@@ -1,0 +1,5 @@
+package nl.utwente.group10.ui.exceptions;
+
+public class InvalidInputIdException extends RuntimeException {
+
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/handlers/AnchorHandler.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/handlers/AnchorHandler.java
@@ -65,7 +65,7 @@ public class AnchorHandler implements EventHandler<InputEvent> {
 	}
 	
 	private void inputPressed(int inputId){
-		if (anchor.getConnection().isPresent() && !anchor.canConnect()) {
+		if (anchor.getPrimaryConnection().isPresent() && !anchor.canAddConnection()) {
 			manager.editConnection(inputId, anchor);
 		} else {
 			manager.createConnectionWith(inputId, anchor);

--- a/Code/src/main/java/nl/utwente/group10/ui/handlers/AnchorHandler.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/handlers/AnchorHandler.java
@@ -68,7 +68,7 @@ public class AnchorHandler implements EventHandler<InputEvent> {
 		if (anchor.getPrimaryConnection().isPresent() && !anchor.canAddConnection()) {
 			manager.editConnection(inputId, anchor);
 		} else {
-			manager.createConnectionWith(inputId, anchor);
+			manager.buildConnectionWith(inputId, anchor);
 		}
 	}
 	

--- a/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
@@ -62,7 +62,7 @@ public class ConnectionCreationManager {
         Connection connection = connections.get(id);
         if (connection != null) {
             if (CONNECTIONS_OVERRIDE_EXISTING && !anchor.canAddConnection()) {
-                anchor.clearConnections();
+                anchor.removeConnections();
             }
             
             if (anchor.canAddConnection() && connection.tryAddAnchor(anchor)) {
@@ -86,18 +86,18 @@ public class ConnectionCreationManager {
     }
 
     public void editConnection(int id, ConnectionAnchor anchor) {
-        System.out.println("Edit Connection!");
         Optional<? extends ConnectionAnchor> anchorToKeep = anchor.getPrimaryOppositeAnchor();
         if (anchor.isPrimaryConnected()) {
             Connection connection = anchor.getPrimaryConnection().get();
             connection.disconnect(anchor);
+            System.out.println("editConnection() "+connection);
             connections.put(id, connection);
         }
     }
 
     public void updateLine(int id, double x, double y) {
         Point2D localPos = pane.sceneToLocal(x, y);
-
+        System.out.println("updateLine(): "+connections.get(id));
         if (connections.get(id) != null) {
             connections.get(id).setFreeEnds(localPos.getX(), localPos.getY());
         }

--- a/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
@@ -38,6 +38,9 @@ public class ConnectionCreationManager {
      */
     public static final boolean CONNECTIONS_ALLOW_TYPE_MISMATCH = true;
 
+    /** The int representing the current connection state */
+    private static int connectionState = 0; 
+    
     public ConnectionCreationManager(CustomUIPane pane) {
         this.pane = pane;
         connections = new HashMap<Integer, Connection>();
@@ -58,17 +61,12 @@ public class ConnectionCreationManager {
     public Connection finishConnection(int id, ConnectionAnchor anchor) {
         Connection connection = connections.get(id);
         if (connection != null) {
-            if (CONNECTIONS_OVERRIDE_EXISTING) {
-                Optional<Connection> existingConnection = anchor
-                        .getConnection();
-                if (existingConnection.isPresent()) {
-                    existingConnection.get().disconnect();
-                    pane.getChildren().remove(existingConnection.get());
-                }
+            if (CONNECTIONS_OVERRIDE_EXISTING && !anchor.canAddConnection()) {
+                anchor.clearConnections();
             }
-            if (anchor.canConnect() && connection.tryAddAnchor(anchor)) {
+            
+            if (anchor.canAddConnection() && connection.tryAddAnchor(anchor)) {
                 // Succesfully made connection.
-                pane.invalidate();
             } else {
                 removeConnection(id);
             }
@@ -88,12 +86,12 @@ public class ConnectionCreationManager {
     }
 
     public void editConnection(int id, ConnectionAnchor anchor) {
-        Optional<? extends ConnectionAnchor> anchorToKeep = anchor.getOtherAnchor();
-        if (anchor.hasConnection() && anchorToKeep.isPresent()) {
-            Connection connection = anchor.getConnection().get();
+        System.out.println("Edit Connection!");
+        Optional<? extends ConnectionAnchor> anchorToKeep = anchor.getPrimaryOppositeAnchor();
+        if (anchor.isPrimaryConnected()) {
+            Connection connection = anchor.getPrimaryConnection().get();
             connection.disconnect(anchor);
             connections.put(id, connection);
-            pane.invalidate();
         }
     }
 
@@ -103,5 +101,19 @@ public class ConnectionCreationManager {
         if (connections.get(id) != null) {
             connections.get(id).setFreeEnds(localPos.getX(), localPos.getY());
         }
+    }
+    
+    /**
+     * @return The current connection state.
+     */
+    public static int getConnectionState(){
+        return connectionState;
+    }
+    
+    /**
+     * Go to the next connection state.
+     */
+    public static void nextConnectionState(){
+        connectionState++;
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
@@ -13,15 +13,14 @@ import nl.utwente.group10.ui.components.lines.Connection;
 import nl.utwente.group10.ui.exceptions.InvalidInputIdException;
 
 /**
- * A Manager class manly used to keep track of multiple, possibly concurrent,
+ * A Manager class mainly used to keep track of multiple, possibly concurrent,
  * actions performed on Connections.
- * 
  * These actions are associated with an input id.
+ * 
+ * This class also provides the methods to perform actions based on user input.
  * 
  * This class also stores a ConnectionState.
  * This is an always increasing int used to check if components's (connection) states are fresh. 
- * 
- * @author Derk
  *
  */
 public class ConnectionCreationManager {
@@ -62,7 +61,7 @@ public class ConnectionCreationManager {
     /**
      * Creates a new Connection, with the given anchor being part of it (can be
      * either start or end anchor). This Connection is still being made (a
-     * second anchor should be selected).
+     * second anchor still needs to be selected).
      * 
      * @param id
      *            The id associated with the action on which to follow up.
@@ -90,7 +89,6 @@ public class ConnectionCreationManager {
      * 
      * @param id
      *            The id associated with the action on which to follow up.
-     *            This action should have previously undergone buildConnectionWith().
      * @param anchor
      *            The anchor to add to the connection being finished.
      * @return The finished connection.
@@ -102,10 +100,11 @@ public class ConnectionCreationManager {
                 anchor.removeConnections();
             }
             
-            if (anchor.canAddConnection() && connection.tryAddAnchor(anchor)) {
+            if (anchor.canAddConnection() && connection.tryAddAnchor(anchor) && connection.isConnected()) {
                 // Succesfully made connection.
             } else {
                 removeConnection(id);
+                return null;
             }
 
             connections.remove(id);
@@ -145,7 +144,6 @@ public class ConnectionCreationManager {
      *            be disconnected from its connection.
      */
     public void editConnection(int id, ConnectionAnchor anchor) {
-        Optional<? extends ConnectionAnchor> anchorToKeep = anchor.getPrimaryOppositeAnchor();
         if (anchor.isPrimaryConnected()) {
             Connection connection = anchor.getPrimaryConnection().get();
             connection.disconnect(anchor);

--- a/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/handlers/ConnectionCreationManager.java
@@ -10,7 +10,20 @@ import nl.utwente.group10.ui.components.anchors.ConnectionAnchor;
 import nl.utwente.group10.ui.components.anchors.InputAnchor;
 import nl.utwente.group10.ui.components.anchors.OutputAnchor;
 import nl.utwente.group10.ui.components.lines.Connection;
+import nl.utwente.group10.ui.exceptions.InvalidInputIdException;
 
+/**
+ * A Manager class manly used to keep track of multiple, possibly concurrent,
+ * actions performed on Connections.
+ * 
+ * These actions are associated with an input id.
+ * 
+ * This class also stores a ConnectionState.
+ * This is an always increasing int used to check if components's (connection) states are fresh. 
+ * 
+ * @author Derk
+ *
+ */
 public class ConnectionCreationManager {
 
     CustomUIPane pane;
@@ -46,7 +59,18 @@ public class ConnectionCreationManager {
         connections = new HashMap<Integer, Connection>();
     }
 
-    public Connection createConnectionWith(int id, ConnectionAnchor anchor) {
+    /**
+     * Creates a new Connection, with the given anchor being part of it (can be
+     * either start or end anchor). This Connection is still being made (a
+     * second anchor should be selected).
+     * 
+     * @param id
+     *            The id associated with the action on which to follow up.
+     * @param anchor
+     *            The anchor to build a Connection with
+     * @return The newly build Connection object.
+     */
+    public Connection buildConnectionWith(int id, ConnectionAnchor anchor) {
         Connection newConnection = null;
         if (anchor instanceof OutputAnchor) {
             newConnection = new Connection(pane, (OutputAnchor) anchor);
@@ -58,6 +82,19 @@ public class ConnectionCreationManager {
         return newConnection;
     }
 
+    /**
+     * Finishes building the Connection associated with the given ID, by giving
+     * it its second anchor.
+     * 
+     * Throws an InvalidInputException if an invalid input id is given.
+     * 
+     * @param id
+     *            The id associated with the action on which to follow up.
+     *            This action should have previously undergone buildConnectionWith().
+     * @param anchor
+     *            The anchor to add to the connection being finished.
+     * @return The finished connection.
+     */
     public Connection finishConnection(int id, ConnectionAnchor anchor) {
         Connection connection = connections.get(id);
         if (connection != null) {
@@ -70,34 +107,60 @@ public class ConnectionCreationManager {
             } else {
                 removeConnection(id);
             }
+
+            connections.remove(id);
+            return connection;
+        }else{
+            throw new InvalidInputIdException();
         }
-        connections.remove(id);
-        return connection;
     }
 
+    /**
+     * Completely Removes the Connection associated with the given id, that is
+     * to remove the Connection from the Connections being build and from its
+     * pane.
+     * 
+     * @param id
+     *            The id associated with the action on which to follow up.
+     */
     public void removeConnection(int id) {
         Connection connection = connections.get(id);
-        connections.put(id, null);
         if (connection != null) {
-            connection.disconnect();
-            pane.getChildren().remove(connection);
+            connections.put(id, null);
+            connection.remove();
             connections.remove(id);
         }
     }
 
+    /**
+     * Indicates that the primary connection belonging to the given anchor is
+     * being edited. This means that the primary connection of the given anchor
+     * will be disconnected, and stored as if the finishConnection() method was
+     * not called for this connection.
+     * 
+     * @param id
+     *            The id associated with the action on which to follow up.
+     * @param anchor
+     *            The anchor to start the edit operation from, this anchor will
+     *            be disconnected from its connection.
+     */
     public void editConnection(int id, ConnectionAnchor anchor) {
         Optional<? extends ConnectionAnchor> anchorToKeep = anchor.getPrimaryOppositeAnchor();
         if (anchor.isPrimaryConnected()) {
             Connection connection = anchor.getPrimaryConnection().get();
             connection.disconnect(anchor);
-            System.out.println("editConnection() "+connection);
             connections.put(id, connection);
         }
     }
 
+    /**
+     * Updates the Connection's line associated with the given action id to its new position.
+     * @param id    The id associated with the action on which to follow up.
+     * @param x     New X coordinate
+     * @param y     New Y coordinate
+     */
     public void updateLine(int id, double x, double y) {
         Point2D localPos = pane.sceneToLocal(x, y);
-        System.out.println("updateLine(): "+connections.get(id));
         if (connections.get(id) != null) {
             connections.get(id).setFreeEnds(localPos.getX(), localPos.getY());
         }

--- a/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
@@ -64,7 +64,7 @@ public class MainMenu extends ContextMenu {
     }
 
     private void addBlock(Block block) {
-        block.invalidateConnectionVisuals();
+        block.invalidateConnectionState();
         //Let the block adapt to its start state.
         
         parent.getChildren().add(block);

--- a/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
@@ -64,7 +64,7 @@ public class MainMenu extends ContextMenu {
     }
 
     private void addBlock(Block block) {
-        block.invalidate();
+        block.invalidateConnectionVisuals();
         //Let the block adapt to its start state.
         
         parent.getChildren().add(block);


### PR DESCRIPTION
Dit ding begon als een simpele fix om invalidate wat efficienter te maken, dit bleek wat meer werk dan gedacht.
Ondertussen heb ik de ConnectionAnchors helemaal overhoop gehaald, ze houden nu beiden een lijst bij met Connections.

Dit is nog een WIP PR, maar ik dien hem vast zodat anderen hiervan op de hoogte zijn en voor eventuele feedback.

Volgens mij werkt de hele hoop nu, maar de code kan netter en er kan wel wat documentatie bij, dit ga ik op een later moment toevoegen.