### PR TITLE
UI-errors display now gets correctly updated. Small misc fixes.

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/haskell/hindley/HindleyMilner.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/hindley/HindleyMilner.java
@@ -2,6 +2,7 @@ package nl.utwente.group10.haskell.hindley;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
@@ -36,6 +37,8 @@ public final class HindleyMilner {
     }
 
     public static void unify(final Expr context, final Type t1, final Type t2) throws HaskellTypeError {
+        logger.setLevel(Level.OFF);
+        
         final Type a = t1.prune();
         final Type b = t2.prune();
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/hindley/HindleyMilner.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/hindley/HindleyMilner.java
@@ -2,7 +2,6 @@ package nl.utwente.group10.haskell.hindley;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
@@ -37,7 +36,6 @@ public final class HindleyMilner {
     }
 
     public static void unify(final Expr context, final Type t1, final Type t2) throws HaskellTypeError {
-        
         final Type a = t1.prune();
         final Type b = t2.prune();
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/hindley/HindleyMilner.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/hindley/HindleyMilner.java
@@ -37,7 +37,6 @@ public final class HindleyMilner {
     }
 
     public static void unify(final Expr context, final Type t1, final Type t2) throws HaskellTypeError {
-        logger.setLevel(Level.OFF);
         
         final Type a = t1.prune();
         final Type b = t2.prune();

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
@@ -146,6 +146,7 @@ public class VarT extends Type {
      * @return The set of type classes that are in both types.
      */
     public static Set<TypeClass> intersect(VarT a, VarT b) {
+        //TODO: TEMPORARY WORKAROUND
         if (!a.hasConstraints()) return b.constraints;
         if (!b.hasConstraints()) return a.constraints;
         

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
@@ -146,6 +146,9 @@ public class VarT extends Type {
      * @return The set of type classes that are in both types.
      */
     public static Set<TypeClass> intersect(VarT a, VarT b) {
+        if (!a.hasConstraints()) return b.constraints;
+        if (!b.hasConstraints()) return a.constraints;
+        
         final Set<TypeClass> intersection = new HashSet<TypeClass>();
 
         for (TypeClass tc : a.constraints) {

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -139,9 +139,9 @@ public class CustomUIPane extends TactilePane {
     public final void errorAll() {
         for (Node node : getChildren()) {
             if (node instanceof Block) {
-                ((Block) node).error();
+                ((Block) node).setError(true);
             } else if (node instanceof Connection) {
-                ((Connection) node).error();
+                ((Connection) node).setError(true);
             }
         }
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/InputAnchor.java
@@ -57,4 +57,12 @@ public class InputAnchor extends ConnectionAnchor {
             throw new TypeUnavailableException();
         }
     }
+    
+    public Type getSignature() {
+        if (getBlock() instanceof InputBlock) {
+            return ((InputBlock) getBlock()).getInputSignature(this);
+        } else {
+            throw new TypeUnavailableException();
+        }
+    }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -142,5 +142,5 @@ public abstract class Block extends StackPane implements ComponentLoader {
     }
 
     /** DEBUG METHOD trigger the error state for this block */
-    public abstract void error();
+    public abstract void setError(boolean error);
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -146,7 +146,7 @@ public abstract class Block extends StackPane implements ComponentLoader {
      * @param error True to enable, False to disable.
      */
     public void setError(boolean error) {
-        if(error) {
+        if (error) {
             this.getStyleClass().removeAll("error");
             this.getStyleClass().add("error");
         } else {

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -38,8 +38,8 @@ public abstract class Block extends StackPane implements ComponentLoader {
     /** The context menu associated with this block instance. */
     private CircleMenu circleMenu;
     
-    /** The visual state this Block is in */
-    private int visualState;
+    /** The connection state this Block is in */
+    private int connectionState;
 
     /**
      * @param pane
@@ -123,7 +123,7 @@ public abstract class Block extends StackPane implements ComponentLoader {
                     }
                 }
             }
-            this.visualState = state;
+            this.connectionState = state;
         }
     }
 
@@ -138,9 +138,19 @@ public abstract class Block extends StackPane implements ComponentLoader {
      * @return Whether or not the state of the block confirms to the given newest state.
      */
     public boolean connectionStateIsUpToDate(int state) {
-        return this.visualState == state;
+        return this.connectionState == state;
     }
 
-    /** DEBUG METHOD trigger the error state for this block */
-    public abstract void setError(boolean error);
+    /**
+     * Enables or disables the error state of this Block.
+     * @param error True to enable, False to disable.
+     */
+    public void setError(boolean error) {
+        if(error) {
+            this.getStyleClass().removeAll("error");
+            this.getStyleClass().add("error");
+        } else {
+            this.getStyleClass().removeAll("error");
+        }
+    }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -149,7 +149,7 @@ public class DisplayBlock extends Block implements InputBlock {
         if (error) {
             this.getStyleClass().add("error");
         } else {
-            this.getStyleClass().remove("error");
+            this.getStyleClass().removeAll("error");
         }
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -144,7 +144,12 @@ public class DisplayBlock extends Block implements InputBlock {
         return 0;
     }
 
-    public void error() {
-        this.getStyleClass().add("error");
+    @Override
+    public void setError(boolean error) {
+        if (error) {
+            this.getStyleClass().add("error");
+        } else {
+            this.getStyleClass().remove("error");
+        }
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -143,13 +143,4 @@ public class DisplayBlock extends Block implements InputBlock {
     public int getInputIndex(InputAnchor anchor) {
         return 0;
     }
-
-    @Override
-    public void setError(boolean error) {
-        if (error) {
-            this.getStyleClass().add("error");
-        } else {
-            this.getStyleClass().removeAll("error");
-        }
-    }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -367,16 +367,17 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     }
     
     private final void setInputError(int index, boolean error) {
+        ObservableList<String> styleClass = argumentSpace.getChildren().get(index).getStyleClass();
         if (error) {
-            argumentSpace.getChildren().get(index).getStyleClass().removeAll("error");
-            argumentSpace.getChildren().get(index).getStyleClass().add("error");
+            styleClass.removeAll("error");
+            styleClass.add("error");
         } else {
-            argumentSpace.getChildren().get(index).getStyleClass().removeAll("error");
+            styleClass.removeAll("error");
         }
     }
     
     @Override
-    public String toString(){
+    public String toString() {
         return this.getName();
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -363,15 +363,12 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
         for (InputAnchor in : getAllInputs()) {
             setInputError(getInputIndex(in), error);
         }
-        if(error) {
-            this.getStyleClass().add("error");
-        } else {
-            this.getStyleClass().removeAll("error");
-        }
+        super.setError(error);
     }
     
     private final void setInputError(int index, boolean error) {
         if (error) {
+            argumentSpace.getChildren().get(index).getStyleClass().removeAll("error");
             argumentSpace.getChildren().get(index).getStyleClass().add("error");
         } else {
             argumentSpace.getChildren().get(index).getStyleClass().removeAll("error");

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
@@ -102,15 +102,6 @@ public class ValueBlock extends Block implements OutputBlock {
     }
 
     @Override
-    public void setError(boolean error) {
-        if (error) {
-            this.getStyleClass().add("error");
-        } else {
-            this.getStyleClass().removeAll("error");
-        }
-    }
-
-    @Override
     public OutputAnchor getOutputAnchor() {
         return output;
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
@@ -106,7 +106,7 @@ public class ValueBlock extends Block implements OutputBlock {
         if (error) {
             this.getStyleClass().add("error");
         } else {
-            this.getStyleClass().remove("error");
+            this.getStyleClass().removeAll("error");
         }
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
@@ -102,8 +102,12 @@ public class ValueBlock extends Block implements OutputBlock {
     }
 
     @Override
-    public void error() {
-        this.getStyleClass().add("error");
+    public void setError(boolean error) {
+        if (error) {
+            this.getStyleClass().add("error");
+        } else {
+            this.getStyleClass().remove("error");
+        }
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
@@ -35,8 +35,8 @@ public class Connection extends ConnectionLine implements
 
     private CustomUIPane pane;
 
-    /** The visual state this Block is in */
-    private int visualState;
+    /** The connection state this Connection is in */
+    private int connectionState;
 
     public Connection(CustomUIPane pane) {
         this.pane = pane;
@@ -339,7 +339,7 @@ public class Connection extends ConnectionLine implements
             invalidateConnectionState();
             startAnchor.ifPresent(a -> a.getBlock().invalidateConnectionStateCascading(state));
             endAnchor.ifPresent(a -> a.getBlock().invalidateConnectionStateCascading(state));
-            this.visualState = state;
+            this.connectionState = state;
         }
     }
 
@@ -354,7 +354,7 @@ public class Connection extends ConnectionLine implements
      * @return Whether or not the state of the block confirms to the given newest state.
      */
     public boolean connectionStateIsUpToDate(int state) {
-        return this.visualState == state;
+        return this.connectionState == state;
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
@@ -159,7 +159,7 @@ public class Connection extends ConnectionLine implements
         }
     }
 
-    public final boolean typesMatch(Type t1, Type t2){
+    public final boolean typesMatch(Type t1, Type t2) {
         try {
             HindleyMilner.unify(t1, t2);
             // Types successfully unified

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
@@ -5,6 +5,7 @@ import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.CatalogException;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
+import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
 import nl.utwente.group10.haskell.expr.Apply;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Ident;
@@ -50,5 +51,26 @@ public class UnificationTest {
         Expr e2 = new Apply(e1, new Value(new ConstT("Float"), "5.0"));
         Type t2 = e2.analyze(env).prune();
         assertEquals("Float", t2.toHaskellType());
+    }
+    
+    @Test
+    public void testUnifyABool() throws HaskellException{
+        Env env = new HaskellCatalog().asEnvironment();
+
+        Expr e0 = new Ident("const");
+        Type t0 = e0.analyze(env).prune();
+
+        Expr e1 = new Apply(e0, new Ident("undefined"));
+        Type t1 = e1.analyze(env).prune();
+
+        Expr e2 = new Apply(e1, new Ident("undefined"));
+        Type t2 = e2.analyze(env).prune();
+        
+        Type t3 = HindleyMilner.makeVariable();
+        Type t4 = new ConstT("Bool");
+        
+        HindleyMilner.unify(t3, t4);
+        
+        HindleyMilner.unify(t2, t4);
     }
 }


### PR DESCRIPTION
Fixed invalidateConnectionStateCascading() getting called whenever you moved a Block.

Heb het gehele error triggering verbeterd, nu gebaseerd op het invalidaten van de connection state.
Vervolgens worden de error methoden wat netter aangeroepen.
Ik geloof dat we uiteindelijk uitkwamen op geen error weergave in het block, dat gebeurt momenteel wel, maar nu is dit geheel aan de styleclass (geen error styleclass = geen error weergave).