### PR TITLE
Add zoom button toolbar/overlay

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -105,19 +105,11 @@ public class CustomUIPane extends TactilePane {
         // Ignore (drop) scroll events synthesized from touches
         if (scrollEvent.getTouchCount() > 0) return;
 
-        double scale = this.getScaleX();
-        double ratio = 1.0;
-
-        if (scrollEvent.getDeltaY() > 0 && scale < 8) {
-            ratio = 1.25;
-        } else if (scrollEvent.getDeltaY() < 0 && scale > 0.5) {
-            ratio = 0.8;
+        if (scrollEvent.getDeltaY() > 0) {
+            zoomIn();
+        } else if (scrollEvent.getDeltaY() < 0) {
+            zoomOut();
         }
-
-        this.setScale(scale * ratio);
-        this.setTranslateX(this.getTranslateX() * ratio);
-        this.setTranslateY(this.getTranslateY() * ratio);
-
     }
 
     /**
@@ -193,5 +185,25 @@ public class CustomUIPane extends TactilePane {
 
     public Optional<GhciSession> getGhciSession() {
         return ghci;
+    }
+
+    public void zoomOut() {
+        zoom(0.8);
+    }
+
+    public void zoomIn() {
+        zoom(1.25);
+    }
+
+    private void zoom(double ratio) {
+        double scale = this.getScaleX();
+
+        // Limit zoom to reasonable range
+        if (scale <= 0.25 && ratio < 1) return;
+        if (scale >= 8 && ratio > 1) return;
+
+        this.setScale(scale * ratio);
+        this.setTranslateX(this.getTranslateX() * ratio);
+        this.setTranslateY(this.getTranslateY() * ratio);
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -102,6 +102,9 @@ public class CustomUIPane extends TactilePane {
     }
 
     private void handleScroll(ScrollEvent scrollEvent) {
+        // Ignore (drop) scroll events synthesized from touches
+        if (scrollEvent.getTouchCount() > 0) return;
+
         double scale = this.getScaleX();
         double ratio = 1.0;
 

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -36,8 +36,6 @@ public class Main extends Application {
         tactilePane.setMaxWidth(50000);
         tactilePane.setMaxHeight(50000);
 
-        tactilePane.getStylesheets().add("/ui/style.css");
-
         tactilePane.dragProcessingModeProperty().set(EventProcessingMode.HANDLER);
 
         ValueBlock valueBlock = new ValueBlock(tactilePane);
@@ -48,6 +46,9 @@ public class Main extends Application {
         DebugParent debug = new DebugParent(tactilePane);
         debug.registerTactilePane(tactilePane);
         debug.setOverlayVisible(false);
+
+        // Init zoom overlay
+        ZoomOverlay zoomOverlay = new ZoomOverlay(debug, tactilePane);
 
         // Init menu
         ContextMenu menu = new MainMenu(catalog, tactilePane);
@@ -67,7 +68,8 @@ public class Main extends Application {
         }
 
         // Init scene
-        Scene scene = new Scene(debug);
+        Scene scene = new Scene(zoomOverlay);
+        scene.getStylesheets().add("/ui/style.css");
 
         stage.setOnCloseRequest(event -> System.exit(0));
         stage.setScene(scene);

--- a/Code/src/main/java/nl/utwente/group10/ui/ZoomOverlay.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/ZoomOverlay.java
@@ -1,0 +1,33 @@
+package nl.utwente.group10.ui;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+public class ZoomOverlay extends StackPane {
+    public static final Pos BUTTON_POS = Pos.BOTTOM_CENTER;
+
+    public ZoomOverlay(Node child, CustomUIPane pane) {
+        super();
+
+        Button zoomIn = new Button("+");
+        zoomIn.setOnAction(e -> pane.zoomIn());
+
+        Button zoomOut = new Button("–");
+        zoomOut.setOnAction(e -> pane.zoomOut());
+
+        FlowPane buttons = new FlowPane(10, 0, zoomIn, zoomOut);
+        buttons.setPrefSize(100, 20);
+        buttons.setMaxSize(Region.USE_PREF_SIZE, Region.USE_PREF_SIZE);
+        buttons.setPadding(new Insets(10));
+        buttons.getStyleClass().add("zoomButtons");
+        StackPane.setAlignment(buttons, BUTTON_POS);
+
+        buttons.getChildren().setAll(zoomIn, zoomOut);
+        this.getChildren().setAll(child, buttons);
+    }
+}

--- a/Code/src/main/resources/ui/style.css
+++ b/Code/src/main/resources/ui/style.css
@@ -100,3 +100,11 @@ CustomUIPane {
     -fx-text-fill: white;
     -fx-font-weight: bold;
 }
+
+.zoomButtons Button {
+    -fx-font-family: monospace;
+    -fx-font-size: 16px;
+    -fx-text-fill: white;
+    -fx-font-weight: bold;
+    -fx-background-color: rgba(0, 0, 0, 0.3);
+}


### PR DESCRIPTION
Also disables scroll-to-zoom on touch, as the one-finger scroll gesture
conflicted with the one-finger pan gesture.

It should be easy to add other buttons as well, if required.