### PR TITLE
Add slider and RGB blocks

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -14,6 +14,7 @@ import nl.utwente.group10.ghcj.GhciException;
 import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.ui.components.CustomAlert;
 import nl.utwente.group10.ui.components.blocks.DisplayBlock;
+import nl.utwente.group10.ui.components.blocks.SliderBlock;
 import nl.utwente.group10.ui.components.blocks.ValueBlock;
 import nl.utwente.group10.ui.menu.MainMenu;
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -26,18 +26,18 @@ import nl.utwente.group10.ui.components.anchors.InputAnchor;
  */
 public class DisplayBlock extends Block implements InputBlock {
     /** The output String to display **/
-    private StringProperty output;
+    protected StringProperty output;
 
     /** The Anchor that is used as input. */
-    private InputAnchor inputAnchor;
+    protected InputAnchor inputAnchor;
 
     /** The space containing the input anchor. */
     @FXML
-    private Pane anchorSpace;
+    protected Pane anchorSpace;
 
     /** The space containing the output anchor. */
     @FXML
-    private Pane outputSpace;
+    protected Pane outputSpace;
 
     /**
      * Creates a new instance of DisplayBlock.

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -1,5 +1,6 @@
 package nl.utwente.group10.ui.components.blocks;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,11 +46,14 @@ public class DisplayBlock extends Block implements InputBlock {
      *            The pane on which this DisplayBlock resides.
      */
     public DisplayBlock(CustomUIPane pane) {
+        this(pane, "DisplayBlock");
+    }
+    protected DisplayBlock(CustomUIPane pane, String fxml) {
         super(pane);
 
         output = new SimpleStringProperty("New Output");
 
-        this.loadFXML("DisplayBlock");
+        this.loadFXML(fxml);
 
         inputAnchor = new InputAnchor(this, pane);
         anchorSpace.getChildren().add(inputAnchor);
@@ -87,7 +91,7 @@ public class DisplayBlock extends Block implements InputBlock {
     }
 
     /** Invalidates the outputted value and triggers re-evaluation of the value. */
-    public final void invalidateConnectionState() {
+    public void invalidateConnectionState() {
         try {
             Optional<GhciSession> ghci = getPane().getGhciSession();
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -1,6 +1,5 @@
 package nl.utwente.group10.ui.components.blocks;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/RGBBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/RGBBlock.java
@@ -37,7 +37,9 @@ public class RGBBlock extends DisplayBlock {
         if (ghci.isPresent()) {
             try {
                 String result = ghci.get().pull(anchor.asExpr());
-                return (int) Math.round(Double.valueOf(result) * 255);
+                double dbl = Double.valueOf(result);
+                double clamped = Math.max(1.0, Math.min(0.0, dbl));
+                return (int) Math.round(clamped * 255);
             } catch (NumberFormatException | GhciException e) {
                 return 0;
             }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/RGBBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/RGBBlock.java
@@ -1,0 +1,58 @@
+package nl.utwente.group10.ui.components.blocks;
+
+import com.google.common.collect.ImmutableList;
+import javafx.fxml.FXML;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import nl.utwente.group10.ghcj.GhciException;
+import nl.utwente.group10.ghcj.GhciSession;
+import nl.utwente.group10.ui.CustomUIPane;
+import nl.utwente.group10.ui.components.anchors.InputAnchor;
+
+import java.util.Optional;
+
+public class RGBBlock extends DisplayBlock {
+    private InputAnchor r;
+    private InputAnchor g;
+    private InputAnchor b;
+
+    @FXML
+    private Pane well;
+
+    public RGBBlock(CustomUIPane pane) {
+        super(pane, "RGBBlock");
+
+        r = this.getAllInputs().get(0);
+        g = new InputAnchor(this, pane);
+        b = new InputAnchor(this, pane);
+
+        anchorSpace.getChildren().setAll(ImmutableList.of(r, g, b));
+    }
+
+    private int evaluate(InputAnchor anchor) {
+        Optional<GhciSession> ghci = getPane().getGhciSession();
+
+        if (ghci.isPresent()) {
+            try {
+                String result = ghci.get().pull(anchor.asExpr());
+                return (int) Math.round(Double.valueOf(result) * 255);
+            } catch (NumberFormatException | GhciException e) {
+                return 0;
+            }
+        } else {
+            return 0;
+        }
+    }
+
+    public final void invalidateConnectionState() {
+        super.invalidateConnectionState();
+
+        int rv = evaluate(r);
+        int gv = evaluate(g);
+        int bv = evaluate(b);
+
+        well.setBackground(new Background(new BackgroundFill(Color.rgb(rv, gv, bv), null, null)));
+    }
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/RGBBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/RGBBlock.java
@@ -11,7 +11,7 @@ import nl.utwente.group10.ghcj.GhciSession;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.components.anchors.InputAnchor;
 
-import java.util.Optional;
+import java.util.NoSuchElementException;
 
 public class RGBBlock extends DisplayBlock {
     private InputAnchor r;
@@ -32,18 +32,13 @@ public class RGBBlock extends DisplayBlock {
     }
 
     private int evaluate(InputAnchor anchor) {
-        Optional<GhciSession> ghci = getPane().getGhciSession();
+        try {
+            GhciSession ghci = getPane().getGhciSession().get();
+            String result = ghci.pull(anchor.asExpr());
 
-        if (ghci.isPresent()) {
-            try {
-                String result = ghci.get().pull(anchor.asExpr());
-                double dbl = Double.valueOf(result);
-                double clamped = Math.max(1.0, Math.min(0.0, dbl));
-                return (int) Math.round(clamped * 255);
-            } catch (NumberFormatException | GhciException e) {
-                return 0;
-            }
-        } else {
+            double v = Math.max(0.0, Math.min(1.0, Double.valueOf(result)));
+            return (int) Math.round(v * 255);
+        } catch (NumberFormatException | GhciException | NoSuchElementException e) {
             return 0;
         }
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/SliderBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/SliderBlock.java
@@ -1,0 +1,28 @@
+package nl.utwente.group10.ui.components.blocks;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Slider;
+import nl.utwente.group10.ui.CustomUIPane;
+
+import java.io.IOException;
+
+public class SliderBlock extends ValueBlock {
+    @FXML
+    private Slider slider;
+
+    /**
+     * @param pane The parent pane this Block resides on.
+     * @throws IOException when the FXML definition cannot be loaded.
+     */
+    public SliderBlock(CustomUIPane pane) {
+        super(pane, "SliderBlock");
+
+        slider.setValue(0.0);
+        this.setValue("0.0");
+
+        slider.valueProperty().addListener(ev -> {
+            setValue(String.valueOf(slider.getValue()));
+            pane.invalidateAll();
+        });
+    }
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
@@ -39,12 +39,15 @@ public class ValueBlock extends Block implements OutputBlock {
      *            The parent pane this Block resides on.
      */
     public ValueBlock(CustomUIPane pane) {
+        this(pane, "ValueBlock");
+    }
+    protected ValueBlock(CustomUIPane pane, String fxml) {
         super(pane);
 
         value = new SimpleStringProperty("5.0");
         output = new OutputAnchor(this, pane);
 
-        this.loadFXML("ValueBlock");
+        this.loadFXML(fxml);
 
         outputSpace.getChildren().add(this.getOutputAnchor());
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
@@ -13,6 +13,8 @@ import nl.utwente.group10.haskell.catalog.FunctionEntry;
 import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.components.blocks.Block;
+import nl.utwente.group10.ui.components.blocks.RGBBlock;
+import nl.utwente.group10.ui.components.blocks.SliderBlock;
 import nl.utwente.group10.ui.components.blocks.ValueBlock;
 import nl.utwente.group10.ui.components.blocks.DisplayBlock;
 import nl.utwente.group10.ui.components.blocks.FunctionBlock;
@@ -45,8 +47,12 @@ public class MainMenu extends ContextMenu {
         valueBlockItem.setOnAction(event -> addBlock(new ValueBlock(parent)));
         MenuItem displayBlockItem = new MenuItem("Display Block");
         displayBlockItem.setOnAction(event -> addBlock(new DisplayBlock(parent)));
+        MenuItem sliderBlockItem = new MenuItem("Slider Block");
+        sliderBlockItem.setOnAction(event -> addBlock(new SliderBlock(parent)));
+        MenuItem rgbBlockItem = new MenuItem("RGB Block");
+        rgbBlockItem.setOnAction(event -> addBlock(new RGBBlock(parent)));
 
-        // TODO remove this item when debugging of visualFeedback is done
+        //TODO remove this item when debugging of visualFeedback is done
         MenuItem errorItem = new MenuItem("Error all Blocks");
         errorItem.setOnAction(event -> parent.errorAll());
 
@@ -55,7 +61,7 @@ public class MainMenu extends ContextMenu {
 
         SeparatorMenuItem sep = new SeparatorMenuItem();
 
-        this.getItems().addAll(valueBlockItem, displayBlockItem, sep, errorItem, quitItem);
+        this.getItems().addAll(valueBlockItem, displayBlockItem, sliderBlockItem, rgbBlockItem, sep, errorItem, quitItem);
     }
 
     private void addFunctionBlock(FunctionEntry entry) {
@@ -72,5 +78,4 @@ public class MainMenu extends ContextMenu {
         Point2D panePos = parent.screenToLocal(this.getX(), this.getY());
         block.relocate(panePos.getX(), panePos.getY());
     }
-
 }

--- a/Code/src/main/resources/ui/RGBBlock.fxml
+++ b/Code/src/main/resources/ui/RGBBlock.fxml
@@ -1,0 +1,21 @@
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.VBox?>
+<?import nl.utwente.group10.ui.components.blocks.RGBBlock?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.HBox?>
+<fx:root type="nl.utwente.group10.ui.components.blocks.RGBBlock" xmlns:fx="http://javafx.com/fxml/">
+    <BorderPane>
+        <top>
+            <FlowPane fx:id="anchorSpace" prefWrapLength="100" vgap="50" hgap="10" alignment="center"/>
+        </top>
+        <center>
+            <HBox styleClass="display, block">
+                <Pane style="-fx-background-fill: red" prefHeight="75" prefWidth="100" fx:id="well" />
+            </HBox>
+        </center>
+        <bottom>
+            <VBox fx:id="outputSpace" alignment = "center"/>
+        </bottom>
+    </BorderPane>
+</fx:root>

--- a/Code/src/main/resources/ui/SliderBlock.fxml
+++ b/Code/src/main/resources/ui/SliderBlock.fxml
@@ -1,0 +1,20 @@
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.VBox?>
+<?import nl.utwente.group10.ui.components.blocks.ValueBlock?>
+<?import javafx.scene.control.Slider?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.HBox?>
+<fx:root type="nl.utwente.group10.ui.components.blocks.ValueBlock" xmlns:fx="http://javafx.com/fxml/">
+    <BorderPane>
+        <center>
+            <HBox styleClass="value, block">
+                <padding><Insets top="12" right="12" bottom="12" left="12"/></padding>
+                <Slider min="0.0" max="1.0" fx:id="slider"></Slider>
+            </HBox>
+        </center>
+        <bottom>
+            <VBox fx:id="outputSpace" alignment = "center"/>
+        </bottom>
+    </BorderPane>
+
+</fx:root>


### PR DESCRIPTION
The slider block allows inputting floating point values from 0.0 to 1.0 in a
convenient fashion (if you want another range, just add a multiplication or
addition block).

The RGB block displays a triple of floating point values as a colored pane. Of
course, `(0, 0, 0)` is black, while `(1.0, 1.0, 1.0)` is white.