### PR TITLE
Add first version of graph block

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -17,6 +17,7 @@ import nl.utwente.group10.ghcj.GhciSession;
 import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.ui.components.blocks.Block;
+import nl.utwente.group10.ui.components.blocks.FunctionBlock;
 import nl.utwente.group10.ui.components.lines.Connection;
 import nl.utwente.group10.ui.handlers.ConnectionCreationManager;
 
@@ -62,10 +63,10 @@ public class CustomUIPane extends TactilePane {
         int dist = 100;
 
         switch (keyEvent.getCode()) {
-            case UP:     this.setTranslateY(this.getTranslateY() + dist); break;
-            case DOWN:   this.setTranslateY(this.getTranslateY() - dist); break;
-            case LEFT:   this.setTranslateX(this.getTranslateX() + dist); break;
-            case RIGHT:  this.setTranslateX(this.getTranslateX() - dist); break;
+            case W: this.setTranslateY(this.getTranslateY() + dist); break;
+            case S: this.setTranslateY(this.getTranslateY() - dist); break;
+            case A: this.setTranslateX(this.getTranslateX() + dist); break;
+            case D: this.setTranslateX(this.getTranslateX() - dist); break;
 
             case H: // C&C-style
             case BACK_SPACE: // SC-style
@@ -76,6 +77,9 @@ public class CustomUIPane extends TactilePane {
             case EQUALS: this.setScale(this.getScaleX() * 1.25); break;
             case MINUS:  this.setScale(this.getScaleX() * 0.8); break;
             case DIGIT1: this.setScale(1); break;
+
+            case LEFT: bowtieSelected(-1); break;
+            case RIGHT: bowtieSelected(+1); break;
 
             case DELETE:
                 removeSelected();
@@ -182,6 +186,19 @@ public class CustomUIPane extends TactilePane {
     /** Remove the selected block, if any. */
     private void removeSelected() {
         this.getSelectedBlock().ifPresent(this::removeBlock);
+    }
+
+    private void bowtieSelected(int delta) {
+        this.getSelectedBlock().ifPresent(block -> {
+            if (block instanceof FunctionBlock) {
+                FunctionBlock fun = (FunctionBlock) block;
+
+                try {
+                    fun.setBowtieIndex(fun.getBowtieIndex() + delta);
+                } catch (IndexOutOfBoundsException ignored) {
+                }
+            }
+        });
     }
 
     public ConnectionCreationManager getConnectionCreationManager() {

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -17,7 +17,6 @@ import nl.utwente.group10.ghcj.GhciSession;
 import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.ui.components.blocks.Block;
-import nl.utwente.group10.ui.components.blocks.FunctionBlock;
 import nl.utwente.group10.ui.components.lines.Connection;
 import nl.utwente.group10.ui.handlers.ConnectionCreationManager;
 
@@ -63,10 +62,10 @@ public class CustomUIPane extends TactilePane {
         int dist = 100;
 
         switch (keyEvent.getCode()) {
-            case W: this.setTranslateY(this.getTranslateY() + dist); break;
-            case S: this.setTranslateY(this.getTranslateY() - dist); break;
-            case A: this.setTranslateX(this.getTranslateX() + dist); break;
-            case D: this.setTranslateX(this.getTranslateX() - dist); break;
+            case UP:     this.setTranslateY(this.getTranslateY() + dist); break;
+            case DOWN:   this.setTranslateY(this.getTranslateY() - dist); break;
+            case LEFT:   this.setTranslateX(this.getTranslateX() + dist); break;
+            case RIGHT:  this.setTranslateX(this.getTranslateX() - dist); break;
 
             case H: // C&C-style
             case BACK_SPACE: // SC-style
@@ -77,9 +76,6 @@ public class CustomUIPane extends TactilePane {
             case EQUALS: this.setScale(this.getScaleX() * 1.25); break;
             case MINUS:  this.setScale(this.getScaleX() * 0.8); break;
             case DIGIT1: this.setScale(1); break;
-
-            case LEFT: bowtieSelected(-1); break;
-            case RIGHT: bowtieSelected(+1); break;
 
             case DELETE:
                 removeSelected();
@@ -186,19 +182,6 @@ public class CustomUIPane extends TactilePane {
     /** Remove the selected block, if any. */
     private void removeSelected() {
         this.getSelectedBlock().ifPresent(this::removeBlock);
-    }
-
-    private void bowtieSelected(int delta) {
-        this.getSelectedBlock().ifPresent(block -> {
-            if (block instanceof FunctionBlock) {
-                FunctionBlock fun = (FunctionBlock) block;
-
-                try {
-                    fun.setBowtieIndex(fun.getBowtieIndex() + delta);
-                } catch (IndexOutOfBoundsException ignored) {
-                }
-            }
-        });
     }
 
     public ConnectionCreationManager getConnectionCreationManager() {

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/GraphBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/GraphBlock.java
@@ -1,20 +1,27 @@
 package nl.utwente.group10.ui.components.blocks;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.layout.Pane;
+import nl.utwente.group10.haskell.exceptions.HaskellException;
+import nl.utwente.group10.haskell.expr.Apply;
 import nl.utwente.group10.haskell.expr.Expr;
+import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.haskell.type.ConstT;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.components.anchors.InputAnchor;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 public class GraphBlock extends Block implements InputBlock {
     private InputAnchor input;
@@ -24,6 +31,12 @@ public class GraphBlock extends Block implements InputBlock {
 
     @FXML
     private LineChart<Double, Double> chart;
+
+    @FXML
+    private NumberAxis x;
+
+    @FXML
+    private NumberAxis y;
 
     public GraphBlock(CustomUIPane pane) {
         super(pane);
@@ -75,14 +88,47 @@ public class GraphBlock extends Block implements InputBlock {
     public void invalidateConnectionState() {
         ObservableList<XYChart.Series<Double, Double>> lineChartData = FXCollections.observableArrayList();
 
-        LineChart.Series<Double, Double> series1 = new LineChart.Series<>();
-        series1.getData().add(new XYChart.Data<Double, Double>(0.0, 1.0));
-        series1.getData().add(new XYChart.Data<Double, Double>(1.2, 1.4));
-        series1.getData().add(new XYChart.Data<Double, Double>(2.2, 1.9));
-        series1.getData().add(new XYChart.Data<Double, Double>(2.7, 2.3));
-        series1.getData().add(new XYChart.Data<Double, Double>(2.9, 0.5));
+        double step = 0.01;
+        double min = x.getLowerBound();
+        double max = x.getUpperBound();
 
-        lineChartData.add(series1);
+        // Haskell equivalent:
+        // putStrLn $ unwords $ map show $ map (id) [1.0,1.1..5.0]
+        Expr expr = new Apply(
+            new Ident("putStrLn"),
+            new Apply(
+                new Ident("unwords"),
+                new Apply(
+                    new Apply(
+                        new Ident("map"),
+                        new Ident("show")
+                    ),
+                    new Apply(
+                        new Apply(
+                            new Ident("map"),
+                            asExpr()
+                        ),
+                        new Ident(String.format("[%f,%f..%f]", min, min+step, max))
+                    )
+                )
+            )
+        );
+
+        try {
+            String results = getPane().getGhciSession().get().pull(expr);
+
+            LineChart.Series<Double, Double> series = new LineChart.Series<>();
+            ObservableList<XYChart.Data<Double, Double>> data = series.getData();
+            Iterator<String> v = Splitter.on(' ').split(results).iterator();
+
+            for (double i = min; i < max; i += step) {
+                data.add(new XYChart.Data<>(i, Double.valueOf(v.next())));
+            }
+
+            lineChartData.add(series);
+        } catch (HaskellException | NoSuchElementException | NumberFormatException ignored) {
+            // Pretend we didn't hear anything.
+        }
 
         chart.setData(lineChartData);
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/GraphBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/GraphBlock.java
@@ -1,0 +1,89 @@
+package nl.utwente.group10.ui.components.blocks;
+
+import com.google.common.collect.ImmutableList;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.XYChart;
+import javafx.scene.layout.Pane;
+import nl.utwente.group10.haskell.expr.Expr;
+import nl.utwente.group10.haskell.type.ConstT;
+import nl.utwente.group10.haskell.type.FuncT;
+import nl.utwente.group10.haskell.type.Type;
+import nl.utwente.group10.ui.CustomUIPane;
+import nl.utwente.group10.ui.components.anchors.InputAnchor;
+
+import java.util.List;
+
+public class GraphBlock extends Block implements InputBlock {
+    private InputAnchor input;
+
+    @FXML
+    private Pane anchorSpace;
+
+    @FXML
+    private LineChart<Double, Double> chart;
+
+    public GraphBlock(CustomUIPane pane) {
+        super(pane);
+
+        loadFXML("GraphBlock");
+
+        input = new InputAnchor(this, pane);
+        anchorSpace.getChildren().setAll(input);
+    }
+
+    @Override
+    public Expr asExpr() {
+        return input.asExpr();
+    }
+
+    @Override
+    public Type getInputSignature(InputAnchor input) {
+        assert input.equals(this.input);
+        return getInputSignature(0);
+    }
+
+    @Override
+    public Type getInputSignature(int index) {
+        assert index == 0;
+        return new FuncT(new ConstT("Float"), new ConstT("Float"));
+    }
+
+    @Override
+    public Type getInputType(InputAnchor input) {
+        return getInputSignature(0);
+    }
+
+    @Override
+    public Type getInputType(int index) {
+        return getInputSignature(0);
+    }
+
+    @Override
+    public List<InputAnchor> getAllInputs() {
+        return ImmutableList.of(input);
+    }
+
+    @Override
+    public List<InputAnchor> getActiveInputs() {
+        return ImmutableList.of(input);
+    }
+
+    @Override
+    public void invalidateConnectionState() {
+        ObservableList<XYChart.Series<Double, Double>> lineChartData = FXCollections.observableArrayList();
+
+        LineChart.Series<Double, Double> series1 = new LineChart.Series<>();
+        series1.getData().add(new XYChart.Data<Double, Double>(0.0, 1.0));
+        series1.getData().add(new XYChart.Data<Double, Double>(1.2, 1.4));
+        series1.getData().add(new XYChart.Data<Double, Double>(2.2, 1.9));
+        series1.getData().add(new XYChart.Data<Double, Double>(2.7, 2.3));
+        series1.getData().add(new XYChart.Data<Double, Double>(2.9, 0.5));
+
+        lineChartData.add(series1);
+
+        chart.setData(lineChartData);
+    }
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
@@ -13,6 +13,7 @@ import nl.utwente.group10.haskell.catalog.FunctionEntry;
 import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.components.blocks.Block;
+import nl.utwente.group10.ui.components.blocks.GraphBlock;
 import nl.utwente.group10.ui.components.blocks.ValueBlock;
 import nl.utwente.group10.ui.components.blocks.DisplayBlock;
 import nl.utwente.group10.ui.components.blocks.FunctionBlock;
@@ -45,6 +46,8 @@ public class MainMenu extends ContextMenu {
         valueBlockItem.setOnAction(event -> addBlock(new ValueBlock(parent)));
         MenuItem displayBlockItem = new MenuItem("Display Block");
         displayBlockItem.setOnAction(event -> addBlock(new DisplayBlock(parent)));
+        MenuItem graphBlockItem = new MenuItem("Graph Block");
+        graphBlockItem.setOnAction(event -> addBlock(new GraphBlock(parent)));
 
         // TODO remove this item when debugging of visualFeedback is done
         MenuItem errorItem = new MenuItem("Error all Blocks");
@@ -55,7 +58,7 @@ public class MainMenu extends ContextMenu {
 
         SeparatorMenuItem sep = new SeparatorMenuItem();
 
-        this.getItems().addAll(valueBlockItem, displayBlockItem, sep, errorItem, quitItem);
+        this.getItems().addAll(valueBlockItem, displayBlockItem, graphBlockItem, sep, errorItem, quitItem);
     }
 
     private void addFunctionBlock(FunctionEntry entry) {

--- a/Code/src/main/resources/ui/GraphBlock.fxml
+++ b/Code/src/main/resources/ui/GraphBlock.fxml
@@ -1,21 +1,21 @@
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.VBox?>
 <?import nl.utwente.group10.ui.components.blocks.GraphBlock?>
 <?import javafx.scene.chart.LineChart?>
 <?import javafx.scene.chart.NumberAxis?>
+<?import javafx.scene.layout.Pane?>
 <fx:root type="nl.utwente.group10.ui.components.blocks.GraphBlock" xmlns:fx="http://javafx.com/fxml/">
     <BorderPane>
         <top>
             <FlowPane fx:id="anchorSpace" prefWrapLength="100" vgap="50" hgap="10" alignment="center"/>
         </top>
         <center>
-            <VBox styleClass="graph, block" spacing="12">
-                <LineChart prefHeight="300" prefWidth="500" fx:id="chart" createSymbols="false" legendVisible="false">
-                    <xAxis><NumberAxis label="" lowerBound="-3" upperBound="3" tickUnit="1"/></xAxis>
-                    <yAxis><NumberAxis label="" lowerBound="-1" upperBound="1" tickUnit="0.1"/></yAxis>
+            <Pane styleClass="graph, block">
+                <LineChart prefWidth="500" prefHeight="300" fx:id="chart" createSymbols="false" legendVisible="false" animated="false">
+                    <xAxis><NumberAxis fx:id="x" label="" lowerBound="-5" upperBound="5" tickUnit="1" autoRanging="false" /></xAxis>
+                    <yAxis><NumberAxis fx:id="y" label="" lowerBound="-1" upperBound="1" tickUnit="0.1" /></yAxis>
                 </LineChart>
-            </VBox>
+            </Pane>
         </center>
     </BorderPane>
 </fx:root>

--- a/Code/src/main/resources/ui/GraphBlock.fxml
+++ b/Code/src/main/resources/ui/GraphBlock.fxml
@@ -1,0 +1,21 @@
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.VBox?>
+<?import nl.utwente.group10.ui.components.blocks.GraphBlock?>
+<?import javafx.scene.chart.LineChart?>
+<?import javafx.scene.chart.NumberAxis?>
+<fx:root type="nl.utwente.group10.ui.components.blocks.GraphBlock" xmlns:fx="http://javafx.com/fxml/">
+    <BorderPane>
+        <top>
+            <FlowPane fx:id="anchorSpace" prefWrapLength="100" vgap="50" hgap="10" alignment="center"/>
+        </top>
+        <center>
+            <VBox styleClass="graph, block" spacing="12">
+                <LineChart prefHeight="300" prefWidth="500" fx:id="chart" createSymbols="false" legendVisible="false">
+                    <xAxis><NumberAxis label="" lowerBound="-3" upperBound="3" tickUnit="1"/></xAxis>
+                    <yAxis><NumberAxis label="" lowerBound="-1" upperBound="1" tickUnit="0.1"/></yAxis>
+                </LineChart>
+            </VBox>
+        </center>
+    </BorderPane>
+</fx:root>

--- a/Code/src/main/resources/ui/style.css
+++ b/Code/src/main/resources/ui/style.css
@@ -61,6 +61,10 @@ CustomUIPane {
     -fx-background-color: #c0392b;
 }
 
+.graph.block {
+    -fx-background-color: #ecf0f1;
+}
+
 .value.block .title, .display.block .title {
 
 }
@@ -99,4 +103,8 @@ CustomUIPane {
     -fx-padding: 6;
     -fx-text-fill: white;
     -fx-font-weight: bold;
+}
+
+LineChart {
+    -fx-font-size: 14px;
 }


### PR DESCRIPTION
GraphBlocks take a single input: a function from Float to Float (could perhaps
be Floating to Num, I haven't checked). It then draws the results of that function
as a nice-looking line graph by mapping it over a (Haskell-generated) list of
intermediate values.

The horizontal range is fixed for now (from -5 to +5), as is the step size; the
vertical axis will automatically scale with the input data.

This PR also contains a (temporary, I hope) means of changing the bowtie index
on functions with the arrow keys, as without that, it's hard to partially apply
functions.

Like PR #94, this PR depends on `invalidateConnectionState` to do something
that doesn't have anything to do with connection state - I'm not sure how to
fix that.